### PR TITLE
Report tool, rename narrative agent to workspace agent

### DIFF
--- a/narrative_llm_agent/agents/job.py
+++ b/narrative_llm_agent/agents/job.py
@@ -5,10 +5,11 @@ from langchain.pydantic_v1 import BaseModel, Field
 from langchain.tools import tool
 import json
 from narrative_llm_agent.kbase.clients.execution_engine import ExecutionEngine
+from narrative_llm_agent.util.tool import process_tool_input
 
 
 class JobInput(BaseModel):
-    job_id: str = Field(description="The unique identifier for a job running in the KBase Execution Engine. This must be a 24 character hexadecimal string.")
+    job_id: str = Field(description="The unique identifier for a job running in the KBase Execution Engine. This must be a 24 character hexadecimal string. This must not be a dictionary or JSON-formatted string.")
 
 class JobAgent(KBaseAgent):
     role: str = "Job Manager"
@@ -31,7 +32,7 @@ class JobAgent(KBaseAgent):
             permission to see the job, this raises a JobError. job_id must be a 24 character
             hexadecimal string. Do not pass in a dictionary or a JSON-formatted string.
             """
-            return self._job_status(job_id)
+            return self._job_status(process_tool_input(job_id, "job_id"))
 
         self.agent = Agent(
             role=self.role,

--- a/narrative_llm_agent/agents/narrative.py
+++ b/narrative_llm_agent/agents/narrative.py
@@ -5,7 +5,7 @@ from langchain.pydantic_v1 import BaseModel, Field
 from langchain.tools import tool
 import json
 from narrative_llm_agent.kbase.clients.workspace import Workspace
-from util.workspace import WorkspaceUtil
+from narrative_llm_agent.util.workspace import WorkspaceUtil
 
 
 class NarrativeInput(BaseModel):

--- a/narrative_llm_agent/agents/narrative.py
+++ b/narrative_llm_agent/agents/narrative.py
@@ -6,6 +6,7 @@ from langchain.tools import tool
 import json
 from narrative_llm_agent.kbase.clients.workspace import Workspace
 from narrative_llm_agent.util.workspace import WorkspaceUtil
+from narrative_llm_agent.util.tool import process_tool_input
 
 
 class NarrativeInput(BaseModel):
@@ -37,7 +38,7 @@ class NarrativeAgent(KBaseAgent):
             """Fetch a list of objects available in a KBase Narrative. This returns a JSON-formatted
             list of all objects in a narrative. The narrative_id input must be an integer. Do not
             pass in a dictionary or a JSON-formatted string."""
-            return self._list_objects(narrative_id)
+            return self._list_objects(process_tool_input(narrative_id, "narrative_id"))
 
         @tool(args_schema=UpaInput, return_direct=False)
         def get_report(upa: str) -> str:
@@ -50,14 +51,14 @@ class NarrativeAgent(KBaseAgent):
             key "report-text" and the HTML data is under the key "HTML-report". The upa input must be
             a string with format number/number/number. Do not input a dictionary or a JSON-formatted
             string."""
-            return self._get_report(upa)
+            return self._get_report(process_tool_input(upa, "upa"))
 
         @tool(args_schema=UpaInput, return_direct=False)
         def get_object(upa: str) -> str:
             """Fetch a particular object from a KBase Narrative. This returns a JSON-formatted data object
             from the Workspace service. Its format is dependent on the data type. The upa input must be a
             string with format number/number/number. Do not input a dictionary or a JSON-formatted string."""
-            return self._get_object(upa)
+            return self._get_object(process_tool_input(upa, "upa"))
 
         self.agent = Agent(
             role = self.role,

--- a/narrative_llm_agent/agents/narrative.py
+++ b/narrative_llm_agent/agents/narrative.py
@@ -96,5 +96,5 @@ class NarrativeAgent(KBaseAgent):
         Fetches a report object from the workspace service. If it is not
         a report, this raises a ValueError.
         """
-        ws_util = WorkspaceUtil(self._token, endpoint=KBaseAgent._service_endpoint)
+        ws_util = WorkspaceUtil(self._token, KBaseAgent._service_endpoint)
         return ws_util.get_report(upa)

--- a/narrative_llm_agent/agents/workspace.py
+++ b/narrative_llm_agent/agents/workspace.py
@@ -19,7 +19,7 @@ class UpaInput(BaseModel):
                      For example, '11/22/33'.""")
 
 
-class NarrativeAgent(KBaseAgent):
+class WorkspaceAgent(KBaseAgent):
     role: str = "Workspace Manager"
     goal: str = "Retrieve data from the KBase Narrative. Filter and interpret datasets as necessary to achieve team goals."
     backstory: str = """You are an expert in bioinformatics and data science, with years of experience working with the DoE KBase system.
@@ -28,11 +28,11 @@ class NarrativeAgent(KBaseAgent):
     You are closely familiar with the Workspace service and all of its functionality."""
     ws_endpoint: str = KBaseAgent._service_endpoint + "ws"
 
-    def __init__(self: "NarrativeAgent", token: str, llm: LLM) -> "NarrativeAgent":
+    def __init__(self: "WorkspaceAgent", token: str, llm: LLM) -> "WorkspaceAgent":
         super().__init__(token, llm)
         self.__init_agent()
 
-    def __init_agent(self: "NarrativeAgent"):
+    def __init_agent(self: "WorkspaceAgent"):
         @tool(args_schema=NarrativeInput, return_direct=False)
         def list_objects(narrative_id: int) -> str:
             """Fetch a list of objects available in a KBase Narrative. This returns a JSON-formatted
@@ -74,7 +74,7 @@ class NarrativeAgent(KBaseAgent):
             allow_delegation=False
         )
 
-    def _list_objects(self: "NarrativeAgent", narrative_id: int) -> str:
+    def _list_objects(self: "WorkspaceAgent", narrative_id: int) -> str:
         """
         Fetches the list of objects in a narrative. Returns the object
         list as stringified JSON.
@@ -83,7 +83,7 @@ class NarrativeAgent(KBaseAgent):
         ws = Workspace(self._token, endpoint=self.ws_endpoint)
         return json.dumps(ws.list_workspace_objects(narrative_id))
 
-    def _get_object(self: "NarrativeAgent", upa: str) -> dict:
+    def _get_object(self: "WorkspaceAgent", upa: str) -> dict:
         """
         Fetches a single object from the workspace service. Returns it
         as a dictionary, structured as per the object type.
@@ -91,7 +91,7 @@ class NarrativeAgent(KBaseAgent):
         ws = Workspace(self._token, endpoint=self.ws_endpoint)
         return ws.get_objects([upa])[0]
 
-    def _get_report(self: "NarrativeAgent", upa: str) -> dict:
+    def _get_report(self: "WorkspaceAgent", upa: str) -> dict:
         """
         Fetches a report object from the workspace service. If it is not
         a report, this raises a ValueError.

--- a/narrative_llm_agent/util/tool.py
+++ b/narrative_llm_agent/util/tool.py
@@ -1,0 +1,39 @@
+import json
+import numbers
+
+def process_tool_input(input_val, expected_key: str) -> str:
+    """
+    Post-processes a tool input. Agents and some LLMs seem to really like sending inputs
+    to tools not just as the input string but as a dictionary with that string.
+    So if there's a tool like
+
+    def do_things(input_val: str) -> str:
+        ...
+
+    it'll often get invoked as
+    do_things({"input_val": "some input"})
+
+    instead of
+    do_things("some input")
+
+    This looks at the input and unpacks it if it's a JSON string and returns the expected
+    key if present, or None otherwise.
+
+    If it's not a JSON string, it just returns the value.
+    """
+    if input_val is None:
+        return None
+    if isinstance(input_val, dict):
+        return input_json.get(expected_key, None)
+    if isinstance(input_val, numbers.Number):
+        return str(input_val)
+    if not isinstance(input_val, str):
+        return None
+    try:
+        input_json = json.loads(input_val)
+        print(input_json)
+        if expected_key in input_json:
+            return str(input_json[expected_key])
+        return None
+    except json.JSONDecodeError:
+        return str(input_val)

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -76,7 +76,7 @@ class WorkspaceUtil:
         obj = self._ws.get_objects([upa])[0]
         if "info" not in obj or len(obj["info"]) < 10:
             raise ValueError(f"Object with UPA {upa} does not appear to be properly formatted.")
-        if not self.is_report(obj["info"][2]):
+        if not self._is_report(obj["info"][2]):
             raise ValueError(f"Object with UPA {upa} is not a report but a {obj['info'][2]}.")
         # check report source from provenance and process based on its service and method
         report_source = self._get_report_source(obj)

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -79,7 +79,7 @@ class WorkspaceUtil:
         if not self._is_report(obj["info"][2]):
             raise ValueError(f"Object with UPA {upa} is not a report but a {obj['info'][2]}.")
         # check report source from provenance and process based on its service and method
-        report_source = self._get_report_source(obj)
+        report_source = self._get_report_source(obj["provenance"])
         if report_source == "fastqc":
             return json.dumps(self.translate_fastqc_report(KBaseReport(obj["data"])))
         else:
@@ -93,7 +93,7 @@ class WorkspaceUtil:
         report_data = {report_file.name: None for report_file in report.file_links}
         target_file_name = "fastqc_data.txt"
         for report_file in report.file_links:
-            resp = self._download_report_file(report_file)
+            resp = self._download_report_file(report_file, self._token)
             comp_file = zipfile.ZipFile(io.BytesIO(resp.content))
             foi = None
             for data_file in comp_file.filelist:

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -1,0 +1,126 @@
+import json
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+import requests
+import zipfile
+import io
+from pathlib import Path
+
+class LinkedFile:
+    handle: str
+    description: str
+    name: str
+    label: str
+    url: str
+
+    def __init__(self, file_link: dict):
+        for key in ["handle", "description", "name", "label", "URL"]:
+            self.__setattr__(key.lower(), file_link.get(key, ""))
+
+class KBaseReport:
+    raw: dict
+    html_links: list[LinkedFile]
+    file_links: list[LinkedFile]
+    text_message: str
+    direct_html: str
+    direct_html_link_index: int
+    warnings: list[str]
+
+    def __init__(self, report_obj: dict):
+        # process into an easy-to-handle report object.
+        # could probably also use a NamedTuple or something here.
+        # but this should suffice to start
+        self.raw = report_obj
+        self.text_message = report_obj.get("text_message", "")
+        self.direct_html = report_obj.get("direct_html", "")
+        self.direct_html_link_index = report_obj.get("direct_html_link_index", None)
+        self.warnings = report_obj.get("warnings", [])
+
+        self.html_links = [LinkedFile(link) for link in report_obj.get("html_links", [])]
+        self.file_links = [LinkedFile(link) for link in report_obj.get("file_links", [])]
+
+    def __str__(self):
+        return json.dumps(self.raw)
+
+class WorkspaceUtil:
+    _ws: Workspace
+    _service_endpoint: str
+    _token: str
+
+    def __init__(self, token: str, service_endpoint: str):
+        self._token = token
+        self._service_endpoint = service_endpoint
+        self._ws = Workspace(self._token, self._service_endpoint + "ws")
+
+    def _is_report(self, obj_type: str) -> bool:
+        return "KBaseReport.Report" in obj_type
+
+    def _get_report_source(self, provenance: list[dict]) -> str:
+        """
+        Parses the object provenance to get the most likely source method for that report
+        so we can tease apart the structure and return what's necessary for the LLM to do its
+        thing. Should be in the first provenance action.
+
+        Tuned for fastqc right now. Others to come!
+        """
+        recent = provenance[0]
+        if recent.get("method", "").lower() == "runfastqc" and recent.get("service", "").lower() == "kb_fastqc":
+            return "fastqc"
+        return "other"
+
+    def get_report(self, upa: str) -> str:
+        """
+        Fetches a report object and returns the relevant portion, depending on what it's
+        a report for. Which is hard to say. Maybe it needs the app name?
+        """
+        # get and test it's a report
+        obj = self._ws.get_objects([upa])[0]
+        if "info" not in obj or len(obj["info"]) < 10:
+            raise ValueError(f"Object with UPA {upa} does not appear to be properly formatted.")
+        if not self.is_report(obj["info"][2]):
+            raise ValueError(f"Object with UPA {upa} is not a report but a {obj['info'][2]}.")
+        # check report source from provenance and process based on its service and method
+        report_source = self._get_report_source(obj)
+        if report_source == "fastqc":
+            return json.dumps(self.translate_fastqc_report(KBaseReport(obj["data"])))
+        else:
+            return json.dumps(obj)
+
+    def translate_fastqc_report(self, report: KBaseReport) -> dict:
+        """
+        Downloads the report files, which are zipped.
+        Unzips and extracts the relevant report info from "fastqc_data.txt"
+        """
+        report_data = {report_file.name: None for report_file in report.file_links}
+        target_file_name = "fastqc_data.txt"
+        for report_file in report.file_links:
+            resp = self._download_report_file(report_file)
+            comp_file = zipfile.ZipFile(io.BytesIO(resp.content))
+            foi = None
+            for data_file in comp_file.filelist:
+                if Path(data_file.filename).name == target_file_name:
+                    foi = data_file
+                    break
+            if foi is not None:
+                with comp_file.open(data_file) as infile:
+                    report_data[report_file.name] = infile.read().decode("utf-8")
+        return report_data
+
+    def _download_report_file(self, report_file: LinkedFile, token: str) -> requests.Response:
+        url = report_file.url
+        if "shock-api" in url:
+            # url looks like:
+            # https://env.kbase.us/services/shock-api/node/<shock-uuid>
+            # we need to make it look like
+            # https://env.kbase.us/services/data_import_export/download?id=<shock_uuid>&wszip=0&name=<filename>
+            node = url.split("/shock-api/node/")[-1]
+            url = f"{self._service_endpoint}/data_import_export/download?id={node}&wszip=0&name={report_file.name}"
+        headers = {
+            "Authorization": token
+        }
+        resp = requests.get(url, headers=headers)
+        try:
+            resp.raise_for_status()
+        except:
+            raise ValueError(f"HTTP status code {resp.status_code} for report file at {url} (original url {report_file.url})")
+        return resp
+

--- a/tests/util/test_tool.py
+++ b/tests/util/test_tool.py
@@ -1,0 +1,17 @@
+from narrative_llm_agent.util.tool import process_tool_input
+import pytest
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("foo", "foo"),
+        (None, None),
+        (123, "123"),
+        ('{"foo": "bar"}', "bar"),
+        ('{"bar": "bar"}', None)
+    ]
+)
+def test_process_tool_input(test_input, expected):
+    key = "foo"
+    val = process_tool_input(test_input, key)
+    assert val == expected


### PR DESCRIPTION
There'll be a new "narrative manager" type agent who's role will be to add cells to a narrative, and get info about existing narratives. So the previous `NarrativeAgent` gets renamed to `WorkspaceAgent` since that's really what it does anyway.