### PR TITLE
Rewrote report prompt, fixed FastQC report fetcher

### DIFF
--- a/narrative_llm_agent/agents/workspace.py
+++ b/narrative_llm_agent/agents/workspace.py
@@ -41,17 +41,21 @@ class WorkspaceAgent(KBaseAgent):
             pass in a dictionary or a JSON-formatted string."""
             return self._list_objects(process_tool_input(narrative_id, "narrative_id"))
 
+        # """Fetch a report object from a KBase Narrative. This returns a JSON-formatted data object
+        # from the Workspace service. This will be structured in one of two ways. First, it might be
+        # structured so that the keys are filenames and the values are strings that are the reports
+        # from those files. These reports will be plain-text and contain an informational summary of
+        # the data. The second structure will contains both the text of the report, and in the case
+        # of an HTML report, the HTML data and a URL link to the HTML report. The text is under the
+        # key "report-text" and the HTML data is under the key "HTML-report". The upa input must be
+        # a string with format number/number/number. Do not input a dictionary or a JSON-formatted
+        # string. This might take a moment to run, as it fetches data from a database."""
         @tool(args_schema=UpaInput, return_direct=False)
         def get_report(upa: str) -> str:
-            """Fetch a report object from a KBase Narrative. This returns a JSON-formatted data object
-            from the Workspace service. This will be structured in one of two ways. First, it might be
-            structured so that the keys are filenames and the values are strings that are the reports
-            from those files. These reports will be plain-text and contain an informational summary of
-            the data. The second structure will contains both the text of the report, and in the case
-            of an HTML report, the HTML data and a URL link to the HTML report. The text is under the
-            key "report-text" and the HTML data is under the key "HTML-report". The upa input must be
-            a string with format number/number/number. Do not input a dictionary or a JSON-formatted
-            string. This might take a moment to run, as it fetches data from a database."""
+            """Fetch a report object from a KBase Narrative. This returns the full report in plain text.
+            It should be an informational summary of the result of a bioinformatics application. The upa
+            input must be a string with format number/number/number. Do not input a dictionary or a
+            JSON-formatted string. This might take a moment to run, as it fetches data from a database."""
             return self._get_report(process_tool_input(upa, "upa"))
 
         @tool(args_schema=UpaInput, return_direct=False)

--- a/narrative_llm_agent/agents/workspace.py
+++ b/narrative_llm_agent/agents/workspace.py
@@ -51,7 +51,7 @@ class WorkspaceAgent(KBaseAgent):
             of an HTML report, the HTML data and a URL link to the HTML report. The text is under the
             key "report-text" and the HTML data is under the key "HTML-report". The upa input must be
             a string with format number/number/number. Do not input a dictionary or a JSON-formatted
-            string."""
+            string. This might take a moment to run, as it fetches data from a database."""
             return self._get_report(process_tool_input(upa, "upa"))
 
         @tool(args_schema=UpaInput, return_direct=False)

--- a/narrative_llm_agent/kbase/service_client.py
+++ b/narrative_llm_agent/kbase/service_client.py
@@ -61,7 +61,6 @@ class ServiceClient:
             timeout=self._timeout
         )
         if resp.status_code == 500:
-            print(resp.headers)
             error_packet = {}
             if resp.headers.get(CONTENT_TYPE) == APPLICATION_JSON:
                 err = resp.json()

--- a/narrative_llm_agent/util/tool.py
+++ b/narrative_llm_agent/util/tool.py
@@ -31,7 +31,6 @@ def process_tool_input(input_val, expected_key: str) -> str:
         return None
     try:
         input_json = json.loads(input_val)
-        print(input_json)
         if expected_key in input_json:
             return str(input_json[expected_key])
         return None

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -47,11 +47,11 @@ class WorkspaceUtil:
         # check report source from provenance and process based on its service and method
         report_source = self._get_report_source(obj["provenance"])
         if report_source == "fastqc":
-            return json.dumps(self.translate_fastqc_report(KBaseReport(obj["data"])))
+            return self.translate_fastqc_report(KBaseReport(obj["data"]))
         else:
             return json.dumps(obj)
 
-    def translate_fastqc_report(self, report: KBaseReport) -> dict:
+    def translate_fastqc_report(self, report: KBaseReport) -> str:
         """
         Downloads the report files, which are zipped.
         Unzips and extracts the relevant report info from "fastqc_data.txt"
@@ -69,7 +69,11 @@ class WorkspaceUtil:
             if foi is not None:
                 with comp_file.open(data_file) as infile:
                     report_data[report_file.name] = infile.read().decode("utf-8")
-        return report_data
+        report_result = []
+        for idx, [name, value] in enumerate(report_data.items()):
+            report_result.append(f"file {idx+1}: {name}:")
+            report_result.append(value)
+        return "\n".join(report_result)
 
     def _download_report_file(self, report_file: LinkedFile, token: str) -> requests.Response:
         url = report_file.url


### PR DESCRIPTION
The `get_report` tool prompt needed some clarification and focusing to get working right with the latest versions of CrewAI and GPT-4-turbo-preview.

Also tweaks the FastQC report interpreter to always return a string, not a JSON doc. That seems more interpretable by the models.