### PR TITLE
Add the ruff linter and formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store

--- a/narrative_llm_agent/agents/analyst.py
+++ b/narrative_llm_agent/agents/analyst.py
@@ -1,11 +1,13 @@
-from .kbase_agent import KBaseAgent
 from crewai import Agent
 from langchain_core.language_models.llms import LLM
 
+from .kbase_agent import KBaseAgent
+
+
 class AnalystAgent(KBaseAgent):
-    role="Computational Biologist and Geneticist"
-    goal="Analyze and interpret datasets, and make suggestions into next analysis steps."
-    backstory="""You are an expert academic computational biologist with decades of
+    role = "Computational Biologist and Geneticist"
+    goal = "Analyze and interpret datasets, and make suggestions into next analysis steps."
+    backstory = """You are an expert academic computational biologist with decades of
     experience working in microbial genetics. You have published several genome announcement
     papers and have worked extensively with novel sequence data. You understand the most
     common workflows for assembling new genomes from sequence data. You have implemented and
@@ -23,5 +25,5 @@ class AnalystAgent(KBaseAgent):
             backstory=self.backstory,
             verbose=True,
             allow_delegation=True,
-            llm=self._llm
+            llm=self._llm,
         )

--- a/narrative_llm_agent/agents/job.py
+++ b/narrative_llm_agent/agents/job.py
@@ -1,15 +1,21 @@
-from .kbase_agent import KBaseAgent
+import json
+
 from crewai import Agent
-from langchain_core.language_models.llms import LLM
 from langchain.pydantic_v1 import BaseModel, Field
 from langchain.tools import tool
-import json
+from langchain_core.language_models.llms import LLM
+
 from narrative_llm_agent.kbase.clients.execution_engine import ExecutionEngine
 from narrative_llm_agent.util.tool import process_tool_input
 
+from .kbase_agent import KBaseAgent
+
 
 class JobInput(BaseModel):
-    job_id: str = Field(description="The unique identifier for a job running in the KBase Execution Engine. This must be a 24 character hexadecimal string. This must not be a dictionary or JSON-formatted string.")
+    job_id: str = Field(
+        description="The unique identifier for a job running in the KBase Execution Engine. This must be a 24 character hexadecimal string. This must not be a dictionary or JSON-formatted string."
+    )
+
 
 class JobAgent(KBaseAgent):
     role: str = "Job Manager"
@@ -40,9 +46,9 @@ class JobAgent(KBaseAgent):
             goal=self.goal,
             backstory=self.backstory,
             verbose=True,
-            tools = [ job_status ],
+            tools=[job_status],
             llm=self._llm,
-            allow_delegation=False
+            allow_delegation=False,
         )
 
     def _job_status(self: "JobAgent", job_id: str) -> str:

--- a/narrative_llm_agent/agents/kbase_agent.py
+++ b/narrative_llm_agent/agents/kbase_agent.py
@@ -1,13 +1,19 @@
 from crewai import Agent
 from langchain_core.language_models.llms import LLM
 
+
 class KBaseAgent:
     agent: Agent
     _token: str
     _llm: LLM
     _service_endpoint: str
 
-    def __init__(self: "KBaseAgent", token: str, llm: LLM, service_endpoint: str="https://ci.kbase.us/services/") -> None:
+    def __init__(
+        self: "KBaseAgent",
+        token: str,
+        llm: LLM,
+        service_endpoint: str = "https://ci.kbase.us/services/",
+    ) -> None:
         self._token = token
         self._llm = llm
         self.agent = None

--- a/narrative_llm_agent/agents/narrative.py
+++ b/narrative_llm_agent/agents/narrative.py
@@ -1,18 +1,23 @@
-from .kbase_agent import KBaseAgent
 from crewai import Agent
-from langchain_core.language_models.llms import LLM
 from langchain.pydantic_v1 import BaseModel, Field
 from langchain.tools import tool
-from narrative_llm_agent.util.tool import process_tool_input
-from narrative_llm_agent.util.narrative import NarrativeUtil
+from langchain_core.language_models.llms import LLM
+
 from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.util.narrative import NarrativeUtil
+from narrative_llm_agent.util.tool import process_tool_input
+
+from .kbase_agent import KBaseAgent
+
 
 class NarrativeInput(BaseModel):
     narrative_id: int = Field(description="The narrative id. Should be numeric.")
 
+
 class MarkdownCellInput(BaseModel):
     narrative_id: int = Field(description="The narrative id. Should be numeric.")
     markdown_text: str = Field(description="The markdown text. Must be a string.")
+
 
 class NarrativeAgent(KBaseAgent):
     role: str = "Narrative Manager"
@@ -51,17 +56,17 @@ class NarrativeAgent(KBaseAgent):
             return self._add_markdown_cell(narrative_id, markdown_text)
 
         self.agent = Agent(
-            role = self.role,
-            goal = self.goal,
-            backstory = self.backstory,
-            verbose = True,
-            tools = [
+            role=self.role,
+            goal=self.goal,
+            backstory=self.backstory,
+            verbose=True,
+            tools=[
                 get_narrative,
                 # add_app_cell,
-                add_markdown_cell
+                add_markdown_cell,
             ],
             llm=self._llm,
-            allow_delegation=False
+            allow_delegation=False,
         )
 
     def _get_narrative(self, narrative_id: int) -> str:

--- a/narrative_llm_agent/agents/workspace.py
+++ b/narrative_llm_agent/agents/workspace.py
@@ -1,22 +1,28 @@
-from .kbase_agent import KBaseAgent
+import json
+
 from crewai import Agent
-from langchain_core.language_models.llms import LLM
 from langchain.pydantic_v1 import BaseModel, Field
 from langchain.tools import tool
-import json
+from langchain_core.language_models.llms import LLM
+
 from narrative_llm_agent.kbase.clients.workspace import Workspace
-from narrative_llm_agent.util.workspace import WorkspaceUtil
 from narrative_llm_agent.util.tool import process_tool_input
+from narrative_llm_agent.util.workspace import WorkspaceUtil
+
+from .kbase_agent import KBaseAgent
 
 
 class NarrativeInput(BaseModel):
     narrative_id: int = Field(description="The narrative id. Should be numeric.")
 
+
 class UpaInput(BaseModel):
-    upa: str = Field(description="""An object UPA (unique permanent address)
+    upa: str = Field(
+        description="""An object UPA (unique permanent address)
                      representing the location of a Workspace data object.
                      Should be a string of the format ws_id/obj_id/ver.
-                     For example, '11/22/33'.""")
+                     For example, '11/22/33'."""
+    )
 
 
 class WorkspaceAgent(KBaseAgent):
@@ -57,17 +63,13 @@ class WorkspaceAgent(KBaseAgent):
             return self._get_object(process_tool_input(upa, "upa"))
 
         self.agent = Agent(
-            role = self.role,
-            goal = self.goal,
-            backstory = self.backstory,
-            verbose = True,
-            tools = [
-                list_objects,
-                get_object,
-                get_report
-            ],
+            role=self.role,
+            goal=self.goal,
+            backstory=self.backstory,
+            verbose=True,
+            tools=[list_objects, get_object, get_report],
             llm=self._llm,
-            allow_delegation=False
+            allow_delegation=False,
         )
 
     def _list_objects(self: "WorkspaceAgent", narrative_id: int) -> str:

--- a/narrative_llm_agent/kbase/auth.py
+++ b/narrative_llm_agent/kbase/auth.py
@@ -1,9 +1,8 @@
 import requests
 
+
 def check_token(token: str, auth_endpoint: str) -> dict[str, str]:
-    headers = {
-        "Authorization": token
-    }
+    headers = {"Authorization": token}
     resp = requests.get(auth_endpoint, headers=headers, allow_redirects=True)
     try:
         resp.raise_for_status()

--- a/narrative_llm_agent/kbase/clients/execution_engine.py
+++ b/narrative_llm_agent/kbase/clients/execution_engine.py
@@ -1,10 +1,13 @@
 from ..service_client import ServiceClient
 
+
 class ExecutionEngine(ServiceClient):
     default_endpoint: str = "https://kbase.us/services/ee2"
     _service = "execution_engine2"
 
-    def __init__(self: "ExecutionEngine", token: str, endpoint: str=default_endpoint) -> "ExecutionEngine":
+    def __init__(
+        self: "ExecutionEngine", token: str, endpoint: str = default_endpoint
+    ) -> "ExecutionEngine":
         super().__init__(endpoint, self._service, token)
 
     def check_job(self: "ExecutionEngine", job_id: str) -> dict:

--- a/narrative_llm_agent/kbase/clients/workspace.py
+++ b/narrative_llm_agent/kbase/clients/workspace.py
@@ -1,7 +1,9 @@
-from ..service_client import ServiceClient
-from typing import Any
-from copy import deepcopy
 import json
+from copy import deepcopy
+from typing import Any
+
+from ..service_client import ServiceClient
+
 
 class WorkspaceObjectId:
     upa: str
@@ -24,7 +26,9 @@ class WorkspaceObjectId:
         return cls(upa)
 
     @classmethod
-    def from_ids(cls: "WorkspaceObjectId", ws_id: int, obj_id: int, version: int) -> "WorkspaceObjectId":
+    def from_ids(
+        cls: "WorkspaceObjectId", ws_id: int, obj_id: int, version: int
+    ) -> "WorkspaceObjectId":
         return cls(f"{ws_id}/{obj_id}/{version}")
 
     def __repr__(self: "WorkspaceObjectId") -> str:
@@ -32,6 +36,7 @@ class WorkspaceObjectId:
 
     def __str__(self: "WorkspaceObjectId") -> str:
         return self.__repr__()
+
 
 class WorkspaceInfo:
     ws_id: int
@@ -56,31 +61,35 @@ class WorkspaceInfo:
         self.meta = info[8] or {}
 
     def __str__(self: "WorkspaceInfo") -> str:
-        return json.dumps([
-            self.ws_id,
-            self.name,
-            self.owner,
-            self.mod_date,
-            self.max_objid,
-            self.perm,
-            self.global_read,
-            self.lock_status,
-            self.meta
-        ])
+        return json.dumps(
+            [
+                self.ws_id,
+                self.name,
+                self.owner,
+                self.mod_date,
+                self.max_objid,
+                self.perm,
+                self.global_read,
+                self.lock_status,
+                self.meta,
+            ]
+        )
 
 
 class Workspace(ServiceClient):
     default_endpoint: str = "https://kbase.us/services/ws"
     _service = "Workspace"
 
-    def __init__(self: "Workspace", token: str, endpoint: str=default_endpoint) -> None:
+    def __init__(self: "Workspace", token: str, endpoint: str = default_endpoint) -> None:
         super().__init__(endpoint, self._service, token)
 
     def get_workspace_info(self: "Workspace", ws_id: int) -> WorkspaceInfo:
         ws_info = self.simple_call("get_workspace_info", {"id": ws_id})
         return WorkspaceInfo(ws_info)
 
-    def list_workspace_objects(self: "Workspace", ws_id: int, object_type: str=None, as_dict: bool=False) -> list[list]:
+    def list_workspace_objects(
+        self: "Workspace", ws_id: int, object_type: str = None, as_dict: bool = False
+    ) -> list[list]:
         ws_info = self.get_workspace_info(ws_id)
         chunk_size = 10000
         current_max = 0
@@ -90,7 +99,7 @@ class Workspace(ServiceClient):
                 "ids": [ws_id],
                 "minObjectID": current_max,
                 "maxObjectID": current_max + chunk_size,
-                "type": object_type
+                "type": object_type,
             }
             objects += self.simple_call("list_objects", list_obj_params)
             current_max += chunk_size + 1
@@ -98,11 +107,13 @@ class Workspace(ServiceClient):
             return objects
         return [self.obj_info_to_json(info) for info in objects]
 
-    def get_object_upas(self: "Workspace", ws_id: int, object_type: str=None) -> list[WorkspaceObjectId]:
+    def get_object_upas(
+        self: "Workspace", ws_id: int, object_type: str = None
+    ) -> list[WorkspaceObjectId]:
         obj_infos = self.list_workspace_objects(ws_id, object_type=object_type)
         return [WorkspaceObjectId.from_ids(info[6], info[0], info[4]) for info in obj_infos]
 
-    def get_objects(self: "Workspace", refs: list[str], data_paths: list[str]=None) -> dict:
+    def get_objects(self: "Workspace", refs: list[str], data_paths: list[str] = None) -> dict:
         base_params = {}
         if data_paths is not None:
             base_params["included"] = data_paths
@@ -124,5 +135,5 @@ class Workspace(ServiceClient):
             "saved": obj_info[3],
             "version": obj_info[4],
             "saved_by": obj_info[5],
-            "size_bytes": obj_info[9]
+            "size_bytes": obj_info[9],
         }

--- a/narrative_llm_agent/kbase/objects/report.py
+++ b/narrative_llm_agent/kbase/objects/report.py
@@ -2,6 +2,7 @@ import json
 
 REPORT_TYPE = "KBaseReport.Report"
 
+
 class LinkedFile:
     handle: str
     description: str
@@ -12,6 +13,7 @@ class LinkedFile:
     def __init__(self, file_link: dict) -> None:
         for key in ["handle", "description", "name", "label", "URL"]:
             self.__setattr__(key.lower(), file_link.get(key, ""))
+
 
 class KBaseReport:
     raw: dict
@@ -43,4 +45,3 @@ def is_report(obj_type: str) -> bool:
     if not isinstance(obj_type, str):
         return False
     return REPORT_TYPE in obj_type
-

--- a/narrative_llm_agent/kbase/service_client.py
+++ b/narrative_llm_agent/kbase/service_client.py
@@ -1,10 +1,12 @@
-import requests
 import uuid
 from typing import Any
+
+import requests
 
 CONTENT_TYPE = "content-type"
 APPLICATION_JSON = "application/json"
 RESULT = "result"
+
 
 class ServerError(Exception):
     name: str
@@ -12,20 +14,22 @@ class ServerError(Exception):
     message: str
     data: Any
 
-    def __init__(self: "ServerError", name: str, code: int, message: str, data: Any=None):
+    def __init__(self: "ServerError", name: str, code: int, message: str, data: Any = None):
         super(Exception, self).__init__(message)
         self.name = name
         self.code = code
-        self.message = '' if message is None else message
-        self.data = data or ''
+        self.message = "" if message is None else message
+        self.data = data or ""
         # data = JSON RPC 2.0, error = 1.1
 
     def __str__(self):
-        return self.name + ': ' + str(self.code) + '. ' + self.message + \
-            '\n' + self.data
+        return self.name + ": " + str(self.code) + ". " + self.message + "\n" + self.data
+
 
 class ServiceClient:
-    def __init__(self: "ServiceClient", endpoint: str, service: str, token: str=None, timeout: int=1800):
+    def __init__(
+        self: "ServiceClient", endpoint: str, service: str, token: str = None, timeout: int = 1800
+    ):
         self._endpoint = endpoint
         self._service = service
         self._token = token
@@ -37,10 +41,7 @@ class ServiceClient:
     def simple_call(self: "ServiceClient", method: str, params: Any) -> Any:
         return self.make_kbase_jsonrpc_1_call(method, [params])[0]
 
-    def make_kbase_jsonrpc_1_call(
-            self: "ServiceClient",
-            method: str,
-            params: list[Any]) -> Any:
+    def make_kbase_jsonrpc_1_call(self: "ServiceClient", method: str, params: list[Any]) -> Any:
         """
         A very simple JSON-RPC 1 request maker for KBase services.
 
@@ -52,13 +53,10 @@ class ServiceClient:
             "params": params,
             "method": f"{self._service}.{method}",
             "version": "1.1",
-            "id": call_id
+            "id": call_id,
         }
         resp = requests.post(
-            self._endpoint,
-            json=json_rpc_package,
-            headers=self._headers,
-            timeout=self._timeout
+            self._endpoint, json=json_rpc_package, headers=self._headers, timeout=self._timeout
         )
         if resp.status_code == 500:
             error_packet = {}
@@ -67,14 +65,12 @@ class ServiceClient:
                 if "error" in err:
                     error_packet = err["error"]
                     if not isinstance(error_packet, dict):
-                        error_packet = {
-                            "data": err["error"]
-                        }
+                        error_packet = {"data": err["error"]}
             raise ServerError(
                 error_packet.get("name", "Unknown"),
                 error_packet.get("code", 0),
                 error_packet.get("message", resp.text),
-                error_packet.get("data", error_packet.get("error", ""))
+                error_packet.get("data", error_packet.get("error", "")),
             )
 
         resp.raise_for_status()

--- a/narrative_llm_agent/util/narrative.py
+++ b/narrative_llm_agent/util/narrative.py
@@ -1,11 +1,13 @@
+import json
+
+from narrative_llm_agent.kbase.clients.workspace import Workspace
 from narrative_llm_agent.kbase.objects.narrative import (
-    Narrative,
     NARRATIVE_ID_KEY,
     NARRATIVE_TYPE,
-    is_narrative
+    Narrative,
+    is_narrative,
 )
-from narrative_llm_agent.kbase.clients.workspace import Workspace
-import json
+
 
 class NarrativeUtil:
     _ws: Workspace
@@ -49,11 +51,13 @@ class NarrativeUtil:
             "data": narr_obj,
             "objid": obj_id,
             "meta": self._build_save_metadata(narrative),
-            "provenance": [{
-                "service": "narrative_llm_agent",
-                "description": "Saved by a KBase Assistant",
-                "service_ver": "0.0.1"  # TODO: put this somewhere reasonable
-            }]
+            "provenance": [
+                {
+                    "service": "narrative_llm_agent",
+                    "description": "Saved by a KBase Assistant",
+                    "service_ver": "0.0.1",  # TODO: put this somewhere reasonable
+                }
+            ],
         }
         obj_info = self._ws.save_objects(ws_id, [ws_save_obj])[0]
         return obj_info
@@ -64,10 +68,18 @@ class NarrativeUtil:
         Needs to be in string-string key-value-pairs for the Workspace service to allow it.
         """
         narr_meta = narrative.metadata
-        string_keys = ["creator", "is_temporary", "format", "name", "description", "type", "ws_name"]
+        string_keys = [
+            "creator",
+            "is_temporary",
+            "format",
+            "name",
+            "description",
+            "type",
+            "ws_name",
+        ]
         obj_keys = {
             "data_dependencies": [],
-            "job_info": {"queue_time": 0, "run_time": 0, "running": 0, "completed": 0, "error": 0}
+            "job_info": {"queue_time": 0, "run_time": 0, "running": 0, "completed": 0, "error": 0},
         }
         meta = {}
         for key in string_keys:

--- a/narrative_llm_agent/util/tool.py
+++ b/narrative_llm_agent/util/tool.py
@@ -1,6 +1,7 @@
 import json
 import numbers
 
+
 def process_tool_input(input_val, expected_key: str) -> str:
     """
     Post-processes a tool input. Agents and some LLMs seem to really like sending inputs
@@ -36,6 +37,7 @@ def process_tool_input(input_val, expected_key: str) -> str:
         return None
     except json.JSONDecodeError:
         return str(input_val)
+
 
 def convert_to_boolean(param: bool | int | float | str) -> bool:
     """

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -1,14 +1,13 @@
-import json
-from narrative_llm_agent.kbase.clients.workspace import Workspace
-import requests
-import zipfile
 import io
+import json
+import zipfile
 from pathlib import Path
-from narrative_llm_agent.kbase.objects.report import (
-    KBaseReport,
-    LinkedFile,
-    is_report
-)
+
+import requests
+
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.kbase.objects.report import KBaseReport, LinkedFile, is_report
+
 
 class WorkspaceUtil:
     _ws: Workspace
@@ -29,7 +28,10 @@ class WorkspaceUtil:
         Tuned for fastqc right now. Others to come!
         """
         recent = provenance[0]
-        if recent.get("method", "").lower() == "runfastqc" and recent.get("service", "").lower() == "kb_fastqc":
+        if (
+            recent.get("method", "").lower() == "runfastqc"
+            and recent.get("service", "").lower() == "kb_fastqc"
+        ):
             return "fastqc"
         return "other"
 
@@ -84,12 +86,12 @@ class WorkspaceUtil:
             # https://env.kbase.us/services/data_import_export/download?id=<shock_uuid>&wszip=0&name=<filename>
             node = url.split("/shock-api/node/")[-1]
             url = f"{self._service_endpoint}/data_import_export/download?id={node}&wszip=0&name={report_file.name}"
-        headers = {
-            "Authorization": token
-        }
+        headers = {"Authorization": token}
         resp = requests.get(url, headers=headers)
         try:
             resp.raise_for_status()
         except requests.HTTPError:
-            raise ValueError(f"HTTP status code {resp.status_code} for report file at {url} (original url {report_file.url})")
+            raise ValueError(
+                f"HTTP status code {resp.status_code} for report file at {url} (original url {report_file.url})"
+            )
         return resp

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -90,6 +90,6 @@ class WorkspaceUtil:
         resp = requests.get(url, headers=headers)
         try:
             resp.raise_for_status()
-        except:
+        except requests.HTTPError:
             raise ValueError(f"HTTP status code {resp.status_code} for report file at {url} (original url {report_file.url})")
         return resp

--- a/poetry.lock
+++ b/poetry.lock
@@ -1803,6 +1803,33 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.3.1"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.3.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6b82e3937d0d76554cd5796bc3342a7d40de44494d29ff490022d7a52c501744"},
+    {file = "ruff-0.3.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ae7954c8f692b70e6a206087ae3988acc9295d84c550f8d90b66c62424c16771"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b730f56ccf91225da0f06cfe421e83b8cc27b2a79393db9c3df02ed7e2bbc01"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c78bfa85637668f47bd82aa2ae17de2b34221ac23fea30926f6409f9e37fc927"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6abaad602d6e6daaec444cbf4d9364df0a783e49604c21499f75bb92237d4af"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5f0c21b6914c3c9a25a59497cbb1e5b6c2d8d9beecc9b8e03ee986e24eee072e"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:434c3fc72e6311c85cd143c4c448b0e60e025a9ac1781e63ba222579a8c29200"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78a7025e6312cbba496341da5062e7cdd47d95f45c1b903e635cdeb1ba5ec2b9"},
+    {file = "ruff-0.3.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52b02bb46f1a79b0c1fa93f6495bc7e77e4ef76e6c28995b4974a20ed09c0833"},
+    {file = "ruff-0.3.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11b5699c42f7d0b771c633d620f2cb22e727fb226273aba775a91784a9ed856c"},
+    {file = "ruff-0.3.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:54e5dca3e411772b51194b3102b5f23b36961e8ede463776b289b78180df71a0"},
+    {file = "ruff-0.3.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:951efb610c5844e668bbec4f71cf704f8645cf3106e13f283413969527ebfded"},
+    {file = "ruff-0.3.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09c7333b25e983aabcf6e38445252cff0b4745420fc3bda45b8fce791cc7e9ce"},
+    {file = "ruff-0.3.1-py3-none-win32.whl", hash = "sha256:d937f9b99ebf346e0606c3faf43c1e297a62ad221d87ef682b5bdebe199e01f6"},
+    {file = "ruff-0.3.1-py3-none-win_amd64.whl", hash = "sha256:c0318a512edc9f4e010bbaab588b5294e78c5cdc9b02c3d8ab2d77c7ae1903e3"},
+    {file = "ruff-0.3.1-py3-none-win_arm64.whl", hash = "sha256:d3b60e44240f7e903e6dbae3139a65032ea4c6f2ad99b6265534ff1b83c20afa"},
+    {file = "ruff-0.3.1.tar.gz", hash = "sha256:d30db97141fc2134299e6e983a6727922c9e03c031ae4883a6d69461de722ae7"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2286,4 +2313,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "46a55233f01ac9ea37cc113b7bc0f7824a11906c081a988c8def54de9936fdaa"
+content-hash = "8b337a0200c0113edf7a34809d01904da64193b60249ae73c35de919aec28e74"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,47 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib --cov=narrative_llm_agent -s --verbose --cov-report html --cov-report term"
+
+[tool.ruff]
+line-length = 100
+
+# E203: whitespace before ‘,’, ‘;’, or ‘:’
+# E501: line length
+lint.ignore = [
+    "E203",
+    "E501"
+]
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    "__pypackages__",
+    "_build",
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git-rewrite",
+    ".git",
+    ".github",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "*.pyc",
+    "buck-out",
+    "build",
+    "deps",
+    "dist",
+    "node_modules",
+    "other_schema",
+    "python-coverage",
+    "sample_data",
+    "venv",
+]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
 pytest-mock = "^3.12.0"
 requests-mock = "^1.11.0"
+ruff = "^0.3.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/agents/test_analyst_agent.py
+++ b/tests/agents/test_analyst_agent.py
@@ -1,6 +1,8 @@
 from narrative_llm_agent.agents.analyst import AnalystAgent
 
 token = "not_a_token"
+
+
 def test_init(mock_llm):
     wa = AnalystAgent(token, mock_llm)
     assert wa.role == "Computational Biologist and Geneticist"

--- a/tests/agents/test_job_agent.py
+++ b/tests/agents/test_job_agent.py
@@ -1,10 +1,14 @@
 import json
+
 from narrative_llm_agent.agents.job import JobAgent
 
 token = "not_a_token"
+
+
 def test_init(mock_llm):
     wa = JobAgent(token, mock_llm)
     assert wa.role == "Job Manager"
+
 
 def test_job_status_tool(mock_llm, mock_kbase_jsonrpc_1_call):
     wa = JobAgent(token, mock_llm)

--- a/tests/agents/test_kbase_agent.py
+++ b/tests/agents/test_kbase_agent.py
@@ -1,5 +1,7 @@
 from langchain_core.language_models.llms import LLM
+
 from narrative_llm_agent.agents.kbase_agent import KBaseAgent
+
 
 def test_kbase_agent(mock_llm):
     fake_token = "foo"

--- a/tests/agents/test_kbase_agent.py
+++ b/tests/agents/test_kbase_agent.py
@@ -1,6 +1,5 @@
 from langchain_core.language_models.llms import LLM
 from narrative_llm_agent.agents.kbase_agent import KBaseAgent
-import pytest
 
 def test_kbase_agent(mock_llm):
     fake_token = "foo"

--- a/tests/agents/test_narrative_agent.py
+++ b/tests/agents/test_narrative_agent.py
@@ -1,33 +1,39 @@
-from narrative_llm_agent.agents.narrative import (
-    NarrativeAgent,
-    NarrativeUtil
-)
-from narrative_llm_agent.kbase.objects.narrative import Narrative
 import pytest
+
+from narrative_llm_agent.agents.narrative import NarrativeAgent, NarrativeUtil
+from narrative_llm_agent.kbase.objects.narrative import Narrative
 from tests.test_data.test_data import get_test_narrative
 
 token = "not_a_token"
+
 
 @pytest.fixture
 def test_narrative():
     return Narrative(get_test_narrative(as_dict=True))
 
+
 def test_init(mock_llm):
     na = NarrativeAgent(token, mock_llm)
     assert na.role == "Narrative Manager"
 
+
 def test_get_narrative(mock_llm, mocker, test_narrative):
     wsid = 123
-    mock = mocker.patch.object(NarrativeUtil, "get_narrative_from_wsid", return_value=test_narrative)
+    mock = mocker.patch.object(
+        NarrativeUtil, "get_narrative_from_wsid", return_value=test_narrative
+    )
     na = NarrativeAgent(token, mock_llm)
     narr_str = na._get_narrative(wsid)
     assert narr_str == str(test_narrative)
     mock.assert_called_once_with(wsid)
 
+
 def test_add_markdown_cell(mock_llm, mocker, test_narrative):
     wsid = 123
     md_test = "# Foo\n ## Bar"
-    get_mock = mocker.patch.object(NarrativeUtil, "get_narrative_from_wsid", return_value=test_narrative)
+    get_mock = mocker.patch.object(
+        NarrativeUtil, "get_narrative_from_wsid", return_value=test_narrative
+    )
     save_mock = mocker.patch.object(NarrativeUtil, "save_narrative", return_value=[])
     num_cells = len(test_narrative.cells)
     na = NarrativeAgent(token, mock_llm)

--- a/tests/agents/test_workspace_agent.py
+++ b/tests/agents/test_workspace_agent.py
@@ -1,14 +1,14 @@
 import json
-from narrative_llm_agent.agents.workspace import (
-    Workspace,
-    WorkspaceAgent,
-    WorkspaceUtil
-)
+
+from narrative_llm_agent.agents.workspace import Workspace, WorkspaceAgent, WorkspaceUtil
 
 token = "not_a_token"
+
+
 def test_init(mock_llm):
     wa = WorkspaceAgent(token, mock_llm)
     assert wa.role == "Workspace Manager"
+
 
 def test_list_objects_tool(mock_llm, mocker):
     ws_id = 12345
@@ -18,6 +18,7 @@ def test_list_objects_tool(mock_llm, mocker):
     assert wa._list_objects(ws_id) == json.dumps(obj_list)
     mock.assert_called_once_with(ws_id)
 
+
 def test_get_object_tool(mock_llm, mocker):
     upa = "1/2/3"
     my_obj = {"data": {"some": "data"}}
@@ -25,6 +26,7 @@ def test_get_object_tool(mock_llm, mocker):
     wa = WorkspaceAgent(token, mock_llm)
     assert wa._get_object(upa) == my_obj
     mock.assert_called_once_with([upa])
+
 
 def test_get_report_tool(mock_llm, mocker):
     some_report = "this is a report"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,24 @@
 import pytest
-from narrative_llm_agent.kbase.service_client import ServiceClient
-from .test_data.test_data import get_test_narrative
 from langchain_core.language_models.llms import LLM
+
+from narrative_llm_agent.kbase.service_client import ServiceClient
+
+from .test_data.test_data import get_test_narrative
+
 
 @pytest.fixture
 def mock_auth_request(requests_mock):
-    def auth_request(url: str, token: str, return_value: dict, status_code: int=200):
+    def auth_request(url: str, token: str, return_value: dict, status_code: int = 200):
         requests_mock.register_uri(
             "GET",
             url,
             request_headers={"Authorization": token},
             json=return_value,
-            status_code=status_code
+            status_code=status_code,
         )
+
     return auth_request
+
 
 @pytest.fixture
 def mock_auth_request_ok(mock_auth_request):
@@ -26,11 +31,13 @@ def mock_auth_request_ok(mock_auth_request):
             "name": "llm agency",
             "user": "j_random_user",
             "custom": {},
-            "cachefor": 300000
+            "cachefor": 300000,
         }
         mock_auth_request(url, token, auth_success)
         return auth_success
+
     return auth_request_ok
+
 
 @pytest.fixture
 def mock_auth_request_bad_token(mock_auth_request):
@@ -43,20 +50,24 @@ def mock_auth_request_bad_token(mock_auth_request):
                 "apperror": "Invalid token",
                 "message": "10020 Invalid token",
                 "callid": "12345",
-                "time": 1708720112853
+                "time": 1708720112853,
             }
         }
         mock_auth_request(url, token, unauth_error, status_code=401)
         return unauth_error
+
     return auth_request_bad_token
+
 
 @pytest.fixture
 def mock_kbase_server_error(requests_mock):
     def mock_generic_error(method: str, url: str, err: dict):
         requests_mock.register_uri(method, url, status_code=500, json=err)
+
     return mock_generic_error
 
-def build_jsonrpc_1_response(result: dict, is_error: bool=False, no_result: bool=False):
+
+def build_jsonrpc_1_response(result: dict, is_error: bool = False, no_result: bool = False):
     resp = {
         "id": "12345",
         "version": "1.1",
@@ -68,6 +79,7 @@ def build_jsonrpc_1_response(result: dict, is_error: bool=False, no_result: bool
     else:
         resp["result"] = [result]
     return resp
+
 
 def match_jsonrpc_1_packet(request):
     """
@@ -89,9 +101,10 @@ def match_jsonrpc_1_packet(request):
             return False
     return True
 
+
 @pytest.fixture
 def mock_kbase_jsonrpc_1_call(requests_mock):
-    def kbase_jsonrpc_1_call(url: str, resp: dict, status_code: int=200, no_result: bool=False):
+    def kbase_jsonrpc_1_call(url: str, resp: dict, status_code: int = 200, no_result: bool = False):
         is_error = status_code != 200
         response_packet = build_jsonrpc_1_response(resp, is_error=is_error, no_result=no_result)
         requests_mock.register_uri(
@@ -100,14 +113,18 @@ def mock_kbase_jsonrpc_1_call(requests_mock):
             additional_matcher=match_jsonrpc_1_packet,
             json=response_packet,
             headers={"content-type": "application/json"},
-            status_code=status_code
+            status_code=status_code,
         )
         return response_packet
+
     return kbase_jsonrpc_1_call
+
 
 @pytest.fixture
 def mock_kbase_client_call(requests_mock):
-    def kbase_call(client: ServiceClient, resp: dict, service_method: str=None, status_code: int=200):
+    def kbase_call(
+        client: ServiceClient, resp: dict, service_method: str = None, status_code: int = 200
+    ):
         def match_kbase_service_call(request):
             packet = request.json()
             if "method" not in packet or not isinstance(packet["method"], str):
@@ -127,10 +144,12 @@ def mock_kbase_client_call(requests_mock):
             additional_matcher=match_kbase_service_call,
             json=response_packet,
             headers={"content-type": "application/json"},
-            status_code=status_code
+            status_code=status_code,
         )
         return response_packet
+
     return kbase_call
+
 
 @pytest.fixture
 def sample_narrative_json() -> str:
@@ -141,12 +160,14 @@ def sample_narrative_json() -> str:
     # open it and return the raw JSON str
     return get_test_narrative()
 
+
 class MockLLM(LLM):
     def _call():
         pass
 
     def _llm_type():
         pass
+
 
 @pytest.fixture
 def mock_llm():

--- a/tests/kbase/clients/test_execution_engine.py
+++ b/tests/kbase/clients/test_execution_engine.py
@@ -1,15 +1,17 @@
-from narrative_llm_agent.kbase.clients.execution_engine import ExecutionEngine
 import pytest
+
+from narrative_llm_agent.kbase.clients.execution_engine import ExecutionEngine
 
 token = "not_a_token"
 endpoint = "https://nope.kbase.us/services/not_ee2"
+
 
 @pytest.fixture
 def client():
     return ExecutionEngine(token, endpoint)
 
+
 def test_check_job(mock_kbase_client_call, client):
     expected = {"status": "ok"}
     mock_kbase_client_call(client, expected)
     assert client.check_job("foo") == expected
-

--- a/tests/kbase/clients/test_workspace.py
+++ b/tests/kbase/clients/test_workspace.py
@@ -1,35 +1,24 @@
-from narrative_llm_agent.kbase.clients.workspace import (
-    Workspace,
-    WorkspaceInfo,
-    WorkspaceObjectId
-)
-
 import pytest
+
+from narrative_llm_agent.kbase.clients.workspace import Workspace, WorkspaceInfo, WorkspaceObjectId
 
 token = "not_a_token"
 endpoint = "https://nope.kbase.us/services/not_ws"
+
 
 @pytest.fixture
 def client():
     return Workspace(token, endpoint)
 
+
 def test_get_ws_info(mock_kbase_client_call, client):
     ws_id = 123
-    ws_info = [
-        ws_id,
-        "my_workspace",
-        "me",
-        "some_date",
-        11000,
-        "o",
-        "n",
-        "n",
-        {}
-    ]
+    ws_info = [ws_id, "my_workspace", "me", "some_date", 11000, "o", "n", "n", {}]
     mock_kbase_client_call(client, ws_info)
     expected_info = WorkspaceInfo(ws_info)
     ret_info = client.get_workspace_info(ws_id)
     assert str(expected_info) == str(ret_info)
+
 
 def test_list_workspace_objects(mock_kbase_client_call, client):
     """
@@ -40,9 +29,45 @@ def test_list_workspace_objects(mock_kbase_client_call, client):
     ws_id = 123456
     ws_info = [ws_id, "mine", "me", "123", 3, "o", "n", "n", {}]
     expected_infos = [
-        [1, "foo1", "Object.Type", "123", 4, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}],
-        [2, "foo2", "Object.Type", "123", 5, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}],
-        [3, "foo3", "Object.Type", "123", 6, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}]
+        [
+            1,
+            "foo1",
+            "Object.Type",
+            "123",
+            4,
+            "me",
+            123456,
+            "nope",
+            "noway",
+            1231234,
+            {"some": "meta"},
+        ],
+        [
+            2,
+            "foo2",
+            "Object.Type",
+            "123",
+            5,
+            "me",
+            123456,
+            "nope",
+            "noway",
+            1231234,
+            {"some": "meta"},
+        ],
+        [
+            3,
+            "foo3",
+            "Object.Type",
+            "123",
+            6,
+            "me",
+            123456,
+            "nope",
+            "noway",
+            1231234,
+            {"some": "meta"},
+        ],
     ]
     mock_kbase_client_call(client, ws_info, "get_workspace_info")
     mock_kbase_client_call(client, expected_infos, "list_objects")
@@ -62,20 +87,57 @@ def test_get_object_upas(mock_kbase_client_call, client):
     ws_id = 123456
     ws_info = [ws_id, "mine", "me", "123", 3, "o", "n", "n", {}]
     object_infos = [
-        [1, "foo1", "Object.Type", "123", 4, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}],
-        [2, "foo2", "Object.Type", "123", 5, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}],
-        [3, "foo3", "Object.Type", "123", 6, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}]
+        [
+            1,
+            "foo1",
+            "Object.Type",
+            "123",
+            4,
+            "me",
+            123456,
+            "nope",
+            "noway",
+            1231234,
+            {"some": "meta"},
+        ],
+        [
+            2,
+            "foo2",
+            "Object.Type",
+            "123",
+            5,
+            "me",
+            123456,
+            "nope",
+            "noway",
+            1231234,
+            {"some": "meta"},
+        ],
+        [
+            3,
+            "foo3",
+            "Object.Type",
+            "123",
+            6,
+            "me",
+            123456,
+            "nope",
+            "noway",
+            1231234,
+            {"some": "meta"},
+        ],
     ]
     expected = [
         WorkspaceObjectId.from_upa("123456/1/4"),
         WorkspaceObjectId.from_upa("123456/2/5"),
-        WorkspaceObjectId.from_upa("123456/3/6")
+        WorkspaceObjectId.from_upa("123456/3/6"),
     ]
     mock_kbase_client_call(client, ws_info, "get_workspace_info")
     mock_kbase_client_call(client, object_infos, "list_objects")
     received = client.get_object_upas(ws_id)
     for idx, upa in enumerate(received):
         assert str(upa) == str(expected[idx])
+
 
 def test_get_objects(mock_kbase_client_call, client):
     """
@@ -106,6 +168,7 @@ def test_get_objects(mock_kbase_client_call, client):
     assert client.get_objects(refs) == expected_objs
     assert client.get_objects(refs, ["some/data/paths"]) == expected_objs
 
+
 def test_save_objects(mock_kbase_client_call, client):
     """
     Returns an object info in real life. For the unit test, we're kinda testing
@@ -119,6 +182,7 @@ def test_save_objects(mock_kbase_client_call, client):
     mock_kbase_client_call(client, [obj_info])
     assert client.save_objects(3, [{"myobject": "lives_here"}]) == [obj_info]
 
+
 def test_obj_info_to_json():
     obj_id = 1
     ws_id = 123
@@ -129,7 +193,19 @@ def test_obj_info_to_json():
     saved = "123123123123"
     saved_by = "me"
     size_bytes = 123456
-    info = [obj_id, name, obj_type, saved, ver, saved_by, ws_id, "nope", "also_nope", size_bytes, metadata]
+    info = [
+        obj_id,
+        name,
+        obj_type,
+        saved,
+        ver,
+        saved_by,
+        ws_id,
+        "nope",
+        "also_nope",
+        size_bytes,
+        metadata,
+    ]
     assert Workspace.obj_info_to_json(info) == {
         "ws_id": ws_id,
         "obj_id": obj_id,
@@ -139,5 +215,5 @@ def test_obj_info_to_json():
         "saved": saved,
         "version": ver,
         "saved_by": saved_by,
-        "size_bytes": size_bytes
+        "size_bytes": size_bytes,
     }

--- a/tests/kbase/objects/test_narrative.py
+++ b/tests/kbase/objects/test_narrative.py
@@ -1,3 +1,7 @@
+import json
+
+import pytest
+
 from narrative_llm_agent.kbase.objects.narrative import (
     AppCell,
     BulkImportCell,
@@ -6,24 +10,26 @@ from narrative_llm_agent.kbase.objects.narrative import (
     DataCell,
     KBaseCell,
     MarkdownCell,
-    OutputCell,
-    RawCell,
     Narrative,
     NarrativeMetadata,
-    is_narrative
+    OutputCell,
+    RawCell,
+    is_narrative,
 )
-import json
-import pytest
 
-@pytest.mark.parametrize("type_str,expected", [
-    ("KBaseNarrative.Narrative", True),
-    ("KBaseNarrative.Narrative-1.0", True),
-    ("NotANarrative", False),
-    (None, False),
-    (1, False),
-    (["not", "a", "narrative"], False),
-    ({"not": "a narrative"}, False)
-])
+
+@pytest.mark.parametrize(
+    "type_str,expected",
+    [
+        ("KBaseNarrative.Narrative", True),
+        ("KBaseNarrative.Narrative-1.0", True),
+        ("NotANarrative", False),
+        (None, False),
+        (1, False),
+        (["not", "a", "narrative"], False),
+        ({"not": "a narrative"}, False),
+    ],
+)
 def test_is_narrative(type_str, expected):
     assert is_narrative(type_str) == expected
 
@@ -44,7 +50,9 @@ class TestCell:
         cell = Cell("test_cell", cell_dict)
         assert cell.to_dict() == cell_dict
 
+
 # Similarly, write tests for CodeCell, RawCell, MarkdownCell, KBaseCell, and their subclasses
+
 
 class TestCodeCell:
     def test_init_with_outputs(self):
@@ -62,6 +70,7 @@ class TestCodeCell:
         cell = CodeCell({})
         assert cell.get_info_str() == "jupyter.code"
 
+
 class TestMarkdownCell:
     def test_init(self):
         cell_dict = {"source": "some markdown"}
@@ -72,6 +81,7 @@ class TestMarkdownCell:
     def test_get_info_str(self):
         cell = MarkdownCell({})
         assert cell.get_info_str() == "jupyter.markdown"
+
 
 class TestRawCell:
     def test_init(self):
@@ -84,27 +94,22 @@ class TestRawCell:
         cell = RawCell({})
         assert cell.get_info_str() == "jupyter.raw"
 
+
 # Continue with similar tests for RawCell, MarkdownCell
+
 
 class TestAppCell:
     @pytest.fixture
     def sample_cell_dict(self):
         return {
             "metadata": {
-                "kbase": {
-                    "appCell": {
-                        "app": {
-                            "id": "app_id",
-                            "gitCommitHash": "commit_hash"
-                        }
-                    }
-                }
+                "kbase": {"appCell": {"app": {"id": "app_id", "gitCommitHash": "commit_hash"}}}
             }
         }
 
     def test_init(self, sample_cell_dict):
         cell = AppCell(sample_cell_dict)
-        #TODO
+        # TODO
         assert cell.app_spec is None
         assert cell.app_id is None
         assert cell.app_name is None
@@ -116,6 +121,7 @@ class TestAppCell:
         cell = AppCell(sample_cell_dict)
         assert cell.get_info_str() == "method.app_id/commit_hash"
 
+
 class TestBulkImportCell:
     def test_init(self):
         cell = BulkImportCell({})
@@ -125,6 +131,7 @@ class TestBulkImportCell:
     def test_get_info_str(self):
         cell = BulkImportCell({})
         assert cell.get_info_str() == "kbase.bulk_import"
+
 
 class TestDataCell:
     def test_init(self):
@@ -136,6 +143,7 @@ class TestDataCell:
         cell = DataCell({})
         assert cell.get_info_str() == "kbase.data_viewer"
 
+
 class TestOutputCell:
     def test_init(self):
         cell = OutputCell({})
@@ -146,8 +154,10 @@ class TestOutputCell:
         cell = OutputCell({})
         assert cell.get_info_str() == "kbase.app_output"
 
+
 class TestKBaseCell:
     kb_type = "some_kbase_cell"
+
     def test_init(self):
         cell = KBaseCell(self.kb_type, {})
         assert cell.cell_type == "code"
@@ -156,6 +166,7 @@ class TestKBaseCell:
     def test_get_info_str(self):
         cell = KBaseCell(self.kb_type, {})
         assert cell.get_info_str() == "kbase." + self.kb_type
+
 
 class TestNarrativeMetadata:
     @pytest.fixture
@@ -167,7 +178,7 @@ class TestNarrativeMetadata:
             "description": "Sample description",
             "format": "ipynb",
             "name": "Sample Narrative",
-            "is_temporary": True
+            "is_temporary": True,
         }
 
     def test_init(self, sample_narrative_metadata):
@@ -197,6 +208,7 @@ class TestNarrativeMetadata:
         """Test the to_dict method."""
         narr_meta = NarrativeMetadata(sample_narrative_metadata)
         assert narr_meta.to_dict() == sample_narrative_metadata
+
 
 class TestNarrative:
     def test_init(self, sample_narrative_json):
@@ -231,16 +243,14 @@ class TestNarrative:
 
     def test_add_code_cell(self, sample_narrative_json):
         test_source = "print('this is valid code.')"
-        outputs = [{
-            "data": {
-                "text/plain": [
-                    "'this is valid code.'"
-                ]
-            },
-            "execution_count": 5,
-            "metadata": {},
-            "output_type": "execute_result"
-        }]
+        outputs = [
+            {
+                "data": {"text/plain": ["'this is valid code.'"]},
+                "execution_count": 5,
+                "metadata": {},
+                "output_type": "execute_result",
+            }
+        ]
         narr = Narrative(json.loads(sample_narrative_json))
         num_cells = len(narr.cells)
         new_cell = narr.add_code_cell(test_source, outputs=outputs)
@@ -267,4 +277,3 @@ class TestNarrative:
         assert isinstance(counts, dict)
         total_cells = sum(list(counts.values()))
         assert total_cells == len(narr.cells)
-

--- a/tests/kbase/objects/test_report.py
+++ b/tests/kbase/objects/test_report.py
@@ -1,22 +1,25 @@
-from narrative_llm_agent.kbase.objects.report import (
-    KBaseReport,
-    LinkedFile,
-    is_report
-)
-import pytest
 import json
 
-@pytest.mark.parametrize("type_str,expected", [
-    ("KBaseReport.Report", True),
-    ("KBaseReport.Report-1.0", True),
-    ("NotAReport", False),
-    (None, False),
-    (1, False),
-    (["not", "a", "report"], False),
-    ({"not": "a report"}, False)
-])
+import pytest
+
+from narrative_llm_agent.kbase.objects.report import KBaseReport, LinkedFile, is_report
+
+
+@pytest.mark.parametrize(
+    "type_str,expected",
+    [
+        ("KBaseReport.Report", True),
+        ("KBaseReport.Report-1.0", True),
+        ("NotAReport", False),
+        (None, False),
+        (1, False),
+        (["not", "a", "report"], False),
+        ({"not": "a report"}, False),
+    ],
+)
 def test_is_report(type_str, expected):
     assert is_report(type_str) == expected
+
 
 def test_linked_file():
     my_file = {
@@ -24,7 +27,7 @@ def test_linked_file():
         "description": "a_file",
         "name": "FooFile",
         "label": "ItIsAFile",
-        "URL": "https://totally-a-file.com"
+        "URL": "https://totally-a-file.com",
     }
 
     linked = LinkedFile(my_file)
@@ -33,6 +36,7 @@ def test_linked_file():
     assert linked.name == my_file["name"]
     assert linked.label == my_file["label"]
     assert linked.url == my_file["URL"]
+
 
 @pytest.fixture
 def sample_report_obj():
@@ -43,8 +47,9 @@ def sample_report_obj():
         "direct_html_link_index": 0,
         "warnings": ["warning1", "warning2"],
         "html_links": [{"name": "link1", "url": "http://example.com"}],
-        "file_links": [{"name": "file1", "url": "http://examplefile.com"}]
+        "file_links": [{"name": "file1", "url": "http://examplefile.com"}],
     }
+
 
 def test_report_init(sample_report_obj):
     """Test the initialization of KBaseReport."""
@@ -57,6 +62,7 @@ def test_report_init(sample_report_obj):
     assert all(isinstance(link, LinkedFile) for link in report.html_links)
     assert all(isinstance(link, LinkedFile) for link in report.file_links)
 
+
 def test_report_init_with_missing_fields():
     """Test the initialization with missing fields in the report object."""
     report_obj = {}
@@ -68,6 +74,7 @@ def test_report_init_with_missing_fields():
     assert report.warnings == []
     assert report.html_links == []
     assert report.file_links == []
+
 
 def test_report_str(sample_report_obj):
     """Test the string representation of KBaseReport."""

--- a/tests/kbase/test_auth.py
+++ b/tests/kbase/test_auth.py
@@ -1,20 +1,25 @@
 import json
-from narrative_llm_agent.kbase.auth import check_token
+
 import pytest
+
+from narrative_llm_agent.kbase.auth import check_token
 
 test_auth_url = "https://ci.kbase.us/services/auth/api/V2/token"
 fake_token = "fake-o"
+
 
 def test_check_token_ok(mock_auth_request_ok):
     expected = mock_auth_request_ok(test_auth_url, fake_token)
     response = check_token(fake_token, test_auth_url)
     assert expected == response
 
+
 def test_check_token_bad(mock_auth_request_bad_token):
     mock_auth_request_bad_token(test_auth_url, fake_token)
     with pytest.raises(ValueError) as err:
         check_token(fake_token, test_auth_url)
         assert "The KBase authentication token is invalid." in err
+
 
 def test_check_token_error(mock_kbase_server_error):
     some_err = {"error": "bad things afoot!"}

--- a/tests/kbase/test_service_client.py
+++ b/tests/kbase/test_service_client.py
@@ -1,13 +1,13 @@
-from narrative_llm_agent.kbase.service_client import (
-    ServerError,
-    ServiceClient
-)
-import pytest
 import json
+
+import pytest
+
+from narrative_llm_agent.kbase.service_client import ServerError, ServiceClient
 
 endpoint = "https://ci.kbase.us/services/fakeservice"
 service = "fake_service"
 token = "not_a_token"
+
 
 @pytest.fixture
 def client():
@@ -20,12 +20,13 @@ def test_service_client_ok(mock_kbase_jsonrpc_1_call, client):
     resp = client.simple_call("some_fn", [])
     assert resp == expected
 
+
 def test_service_client_500(mock_kbase_jsonrpc_1_call, client):
     error = {
         "name": "BigFail",
         "code": 666,
         "message": "Biiiig bada boom.",
-        "error": "server fall down."
+        "error": "server fall down.",
     }
     mock_kbase_jsonrpc_1_call(endpoint, error, status_code=500)
     with pytest.raises(ServerError) as exc_info:
@@ -36,13 +37,15 @@ def test_service_client_500(mock_kbase_jsonrpc_1_call, client):
     assert serv_err.message == error["message"]
     assert serv_err.data == error["error"]
 
+
 def test_service_client_malformed_error(mock_kbase_jsonrpc_1_call, client):
-    error = { "some": "error" }
+    error = {"some": "error"}
     response_json = mock_kbase_jsonrpc_1_call(endpoint, error, status_code=500)
     with pytest.raises(ServerError) as exc_info:
         client.simple_call("some_fn", [])
     serv_err = exc_info.value
     assert str(serv_err) == f"Unknown: 0. {json.dumps(response_json)}\n"
+
 
 def test_service_client_malformed_response(mock_kbase_jsonrpc_1_call, client):
     mock_kbase_jsonrpc_1_call(endpoint, {}, no_result=True)

--- a/tests/test_data/test_data.py
+++ b/tests/test_data/test_data.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
 
-def load_test_data_json(file_path: Path, parse_json: bool=True) -> str | list | dict:
+
+def load_test_data_json(file_path: Path, parse_json: bool = True) -> str | list | dict:
     """
     Loads some JSON test data. If parse_json == False, this just returns the
     file contents as a string and doesn't parse the JSON.
@@ -15,10 +16,12 @@ def load_test_data_json(file_path: Path, parse_json: bool=True) -> str | list | 
         return json.loads(data)
     return data
 
+
 def get_test_narrative(as_dict=False) -> str | dict:
     return load_test_data_json(Path("test_narrative.json"), parse_json=as_dict)
 
-def get_test_report(report_type: str, file_url: str=None, html_url: str=None) -> dict:
+
+def get_test_report(report_type: str, file_url: str = None, html_url: str = None) -> dict:
     """
     Allowed report types:
     fastqc

--- a/tests/util/test_narrative_util.py
+++ b/tests/util/test_narrative_util.py
@@ -1,13 +1,15 @@
-from narrative_llm_agent.util.narrative import NarrativeUtil
+from typing import Any
+
+import pytest
+
 from narrative_llm_agent.kbase.clients.workspace import (
     Workspace,
     WorkspaceInfo,
 )
-from narrative_llm_agent.kbase.service_client import ServerError
-import pytest
-from typing import Any
-from tests.test_data.test_data import get_test_narrative
 from narrative_llm_agent.kbase.objects.narrative import Narrative
+from narrative_llm_agent.kbase.service_client import ServerError
+from narrative_llm_agent.util.narrative import NarrativeUtil
+from tests.test_data.test_data import get_test_narrative
 
 
 class MockWorkspaceInfo(WorkspaceInfo):
@@ -19,7 +21,12 @@ class MockWorkspaceInfo(WorkspaceInfo):
 
 
 class MockWorkspace(Workspace):
-    def __init__(self, missing_ws: bool=False, missing_narr_meta: bool=False, wrong_narr_type: bool=False) -> None:
+    def __init__(
+        self,
+        missing_ws: bool = False,
+        missing_narr_meta: bool = False,
+        wrong_narr_type: bool = False,
+    ) -> None:
         self.missing_ws = missing_ws
         self.missing_narr_meta = missing_narr_meta
         self.wrong_narr_type = wrong_narr_type
@@ -41,35 +48,32 @@ class MockWorkspace(Workspace):
         obj_type = "KBaseNarrative.Narrative"
         if self.wrong_narr_type:
             obj_type = "NotANarrative.NotNarrative"
-        return {
-            "info": [1, "my_narrative", obj_type],
-            "data": narr_dict
-        }
+        return {"info": [1, "my_narrative", obj_type], "data": narr_dict}
 
     def _fake_save_narr_info(self, ws_id: int):
         return [
             1,
-            'my_narr',
-            'KBaseNarrative.Narrative-4.0',
-            '2024-02-12T21:25:47+0000',
+            "my_narr",
+            "KBaseNarrative.Narrative-4.0",
+            "2024-02-12T21:25:47+0000",
             5,
-            'me',
+            "me",
             ws_id,
-            'some_ws',
-            'f420c24227bc252cbf8110cd82f769be',
+            "some_ws",
+            "f420c24227bc252cbf8110cd82f769be",
             13549,
             {
-                'creator': 'me',
-                'data_dependencies': '[]',
-                'is_temporary': 'false',
-                'method.kb_fastqc/runFastQC/b7ea69cd0fe0f62e45a8e6ea4ddeba3cba17a8d4': '1',
-                'job_info': '{"queue_time": 0, "run_time": 0, "running": 0, "completed": 0, "error": 0}',
-                'format': 'ipynb',
-                'name': 'My Fancy Narrative',
-                'description': '',
-                'type': 'KBaseNarrative.Narrative',
-                'ws_name': 'some_ws'
-            }
+                "creator": "me",
+                "data_dependencies": "[]",
+                "is_temporary": "false",
+                "method.kb_fastqc/runFastQC/b7ea69cd0fe0f62e45a8e6ea4ddeba3cba17a8d4": "1",
+                "job_info": '{"queue_time": 0, "run_time": 0, "running": 0, "completed": 0, "error": 0}',
+                "format": "ipynb",
+                "name": "My Fancy Narrative",
+                "description": "",
+                "type": "KBaseNarrative.Narrative",
+                "ws_name": "some_ws",
+            },
         ]
 
 
@@ -77,11 +81,13 @@ def test_get_ref_from_wsid():
     nu = NarrativeUtil(MockWorkspace())
     assert nu.get_narrative_ref_from_wsid(666) == "666/1"
 
+
 def test_get_ref_from_wsid_missing_ws():
     nu = NarrativeUtil(MockWorkspace(missing_ws=True))
     with pytest.raises(ServerError) as exc_info:
         nu.get_narrative_ref_from_wsid(123)
     assert "no workspace with id" in str(exc_info.value)
+
 
 def test_get_ref_from_wsid_no_narr():
     nu = NarrativeUtil(MockWorkspace(missing_narr_meta=True))
@@ -89,10 +95,12 @@ def test_get_ref_from_wsid_no_narr():
         nu.get_narrative_ref_from_wsid(123)
     assert "No narrative found in workspace 123" in str(exc_info.value)
 
+
 def test_get_narrative_from_wsid():
     nu = NarrativeUtil(MockWorkspace())
     narr = nu.get_narrative_from_wsid(123)
     assert isinstance(narr, Narrative)
+
 
 def test_get_narrative_from_wsid_wrong_type():
     nu = NarrativeUtil(MockWorkspace(wrong_narr_type=True))
@@ -100,11 +108,14 @@ def test_get_narrative_from_wsid_wrong_type():
         nu.get_narrative_from_wsid(123)
     assert "The object with reference 123/1 is not a KBase Narrative" in str(exc_info.value)
 
+
 def test_get_narrative_from_wsid_missing_ws():
     pass
 
+
 def test_get_narrative_from_wsid_no_narr():
     pass
+
 
 def test_save_narrative(mocker):
     ws_id = 123
@@ -126,12 +137,23 @@ def test_save_narrative(mocker):
     assert obj["type"] == "KBaseNarrative.Narrative"
     assert obj["data"] == narr.to_dict()
     assert str(obj["objid"]) == "1"
-    assert obj["provenance"] == [{
-        "service": "narrative_llm_agent",
-        "description": "Saved by a KBase Assistant",
-        "service_ver": "0.0.1"
-    }]
-    expected_keys = ["creator", "is_temporary", "format", "name", "description",
-                     "type", "ws_name", "data_dependencies", "job_info"]
+    assert obj["provenance"] == [
+        {
+            "service": "narrative_llm_agent",
+            "description": "Saved by a KBase Assistant",
+            "service_ver": "0.0.1",
+        }
+    ]
+    expected_keys = [
+        "creator",
+        "is_temporary",
+        "format",
+        "name",
+        "description",
+        "type",
+        "ws_name",
+        "data_dependencies",
+        "job_info",
+    ]
     for key in expected_keys:
         assert key in obj["meta"]

--- a/tests/util/test_tool.py
+++ b/tests/util/test_tool.py
@@ -1,8 +1,7 @@
-from narrative_llm_agent.util.tool import (
-    process_tool_input,
-    convert_to_boolean
-)
 import pytest
+
+from narrative_llm_agent.util.tool import convert_to_boolean, process_tool_input
+
 
 @pytest.mark.parametrize(
     "test_input,expected",
@@ -14,43 +13,26 @@ import pytest
         ('{"bar": "bar"}', None),
         ([], None),
         ({"foo": "bar"}, "bar"),
-        ({"not_foo": "bar"}, None)
-    ]
+        ({"not_foo": "bar"}, None),
+    ],
 )
 def test_process_tool_input(test_input, expected):
     key = "foo"
     val = process_tool_input(test_input, key)
     assert val == expected
 
-true_booleans = [
-    "foo",
-    "true",
-    "truthy",
-    True,
-    1,
-    "1",
-    [],
-    {},
-    0.0001,
-    1.5,
-    convert_to_boolean
-]
-@pytest.mark.parametrize(
-    "test_input",
-    [(truthy) for truthy in true_booleans]
-)
+
+true_booleans = ["foo", "true", "truthy", True, 1, "1", [], {}, 0.0001, 1.5, convert_to_boolean]
+
+
+@pytest.mark.parametrize("test_input", [(truthy) for truthy in true_booleans])
 def test_convert_to_boolean_true(test_input):
     assert convert_to_boolean(test_input) is True
 
-false_booleans = [
-    False,
-    "false",
-    "is false",
-    0,
-    None
-]
-@pytest.mark.parametrize(
-    "test_input", [(falsy) for falsy in false_booleans]
-)
+
+false_booleans = [False, "false", "is false", 0, None]
+
+
+@pytest.mark.parametrize("test_input", [(falsy) for falsy in false_booleans])
 def test_convert_to_boolean_false(test_input):
     assert convert_to_boolean(test_input) is False

--- a/tests/util/test_workspace_util.py
+++ b/tests/util/test_workspace_util.py
@@ -1,13 +1,16 @@
+import json
+from pathlib import Path
+
+import pytest
+
 from narrative_llm_agent.kbase.clients.workspace import Workspace
 from narrative_llm_agent.util.workspace import WorkspaceUtil
 from tests.test_data.test_data import get_test_report
-from pathlib import Path
-import pytest
-import json
 
 # just need to mock a single workspace call
 token = "not_a_token"
 endpoint = "https://notreal.kbase.us/services/"
+
 
 @pytest.fixture
 def mocked_ws_util(mocker):
@@ -15,17 +18,21 @@ def mocked_ws_util(mocker):
     Returns a WorkspaceUtil object with a mocked Workspace client that
     only gets the given report data object
     """
+
     def make_mocked_util(report):
         ws_util = WorkspaceUtil(token, endpoint)
         mocker.patch.object(ws_util._ws, "get_objects", return_value=[report])
         return ws_util
+
     return make_mocked_util
+
 
 def test_init():
     ws_util = WorkspaceUtil(token, endpoint)
     assert ws_util._token == token
     assert ws_util._service_endpoint == endpoint
     assert isinstance(ws_util._ws, Workspace)
+
 
 def test_get_report_fastqc_ok(mocked_ws_util, requests_mock):
     file_url = "https://notreal.kbase.us/file/report_file"
@@ -35,7 +42,9 @@ def test_get_report_fastqc_ok(mocked_ws_util, requests_mock):
     with open(report_zip_path, "rb") as archive:
         report_archive = archive.read()
     requests_mock.get(file_url, content=report_archive)
-    with open(Path(__file__).parent / ".." / "test_data" / "test_report_dir" / "fastqc_data.txt") as report_file:
+    with open(
+        Path(__file__).parent / ".." / "test_data" / "test_report_dir" / "fastqc_data.txt"
+    ) as report_file:
         report_text = report_file.read()
     expected_report = []
     for idx, file in enumerate(report["data"]["file_links"]):
@@ -43,26 +52,35 @@ def test_get_report_fastqc_ok(mocked_ws_util, requests_mock):
         expected_report.append(report_text)
     assert ws_util.get_report("1/2/3") == "\n".join(expected_report)
 
+
 def test_get_report_fastqc_shock(mocker, requests_mock):
     pass
 
+
 def test_get_report_bad_dl(mocker, requests_mock):
     pass
+
 
 def test_get_report_bad_info(mocked_ws_util):
     report = get_test_report("fastqc")
     report["info"] = []
     ws_util = mocked_ws_util(report)
-    with pytest.raises(ValueError, match="Object with UPA 1/2/3 does not appear to be properly formatted."):
+    with pytest.raises(
+        ValueError, match="Object with UPA 1/2/3 does not appear to be properly formatted."
+    ):
         ws_util.get_report("1/2/3")
+
 
 def test_get_report_bad_type(mocked_ws_util):
     report = get_test_report("fastqc")
     wrong_type = "NotAReport.Object-1.0"
     report["info"][2] = wrong_type
     ws_util = mocked_ws_util(report)
-    with pytest.raises(ValueError, match=f"Object with UPA 1/2/3 is not a report but a {wrong_type}."):
+    with pytest.raises(
+        ValueError, match=f"Object with UPA 1/2/3 is not a report but a {wrong_type}."
+    ):
         ws_util.get_report("1/2/3")
+
 
 def test_get_other_report(mocked_ws_util):
     report = get_test_report("other")


### PR DESCRIPTION
I don't know how strictly we want to enforce linting / formatting, but `ruff` is a very simple tool to use. It's added to the `poetry` file here. Use it with:

* `ruff check` to do lint checks
* `ruff --fix .` to automatically do what it can for linting
* `ruff format --check` to run the formatter checker - effectively runs `black` (another popular formatter) over the codebase
* `ruff format` goes through and does the formatting.

It's super configurable with lots of options. It should help keep code looking (mostly) uniform and clean. https://docs.astral.sh/ruff/