### PR TITLE
add get_report_from_job_id tool to WorkspaceAgent

### DIFF
--- a/narrative_llm_agent/agents/analyst.py
+++ b/narrative_llm_agent/agents/analyst.py
@@ -29,7 +29,11 @@ class AnalystAgent(KBaseAgent):
     )
     backstory = """You are an expert academic computational biologist with decades of
     experience working in microbial genetics. You have published several genome announcement
-    papers and have worked extensively with novel sequence data."""
+    papers and have worked extensively with novel sequence data. You are an experienced expert
+    at data analysis and interpretation. You have a talent for delegating data retrieval and
+    job running tasks to your coworkers. You don't do much of the work of data generation,
+    but are very good at coordinating tasks among your coworkers, managing their process,
+    and extracting knowledge from the results."""
     _openai_key: str
     _catalog_db_dir: Path
     _docs_db_dir: Path
@@ -118,7 +122,7 @@ class AnalystAgent(KBaseAgent):
             return self._create_doc_chain(persist_directory=self._catalog_db_dir).invoke(
                 {"query": input}
             )
-    
+
         self.agent = Agent(
             role=self.role,
             goal=self.goal,

--- a/narrative_llm_agent/agents/workspace.py
+++ b/narrative_llm_agent/agents/workspace.py
@@ -5,6 +5,7 @@ from langchain.pydantic_v1 import BaseModel, Field
 from langchain.tools import tool
 import json
 from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.kbase.clients.execution_engine import ExecutionEngine
 from narrative_llm_agent.util.workspace import WorkspaceUtil
 from narrative_llm_agent.util.tool import process_tool_input
 
@@ -18,6 +19,11 @@ class UpaInput(BaseModel):
                      Should be a string of the format ws_id/obj_id/ver.
                      For example, '11/22/33'.""")
 
+class JobInput(BaseModel):
+    job_id: str = Field(description="""The unique identifier for a job running
+                        in the KBase Execution Engine. This must be a 24 character
+                        hexadecimal string. This must not be a dictionary or
+                        JSON-formatted string.""")
 
 class WorkspaceAgent(KBaseAgent):
     role: str = "Workspace Manager"
@@ -32,6 +38,7 @@ class WorkspaceAgent(KBaseAgent):
         super().__init__(token, llm)
         self.__init_agent()
         self.ws_endpoint = self._service_endpoint + "ws"
+        self.ee_endpoint = self._service_endpoint + "ee2"
 
     def __init_agent(self: "WorkspaceAgent"):
         @tool(args_schema=NarrativeInput, return_direct=False)
@@ -49,6 +56,12 @@ class WorkspaceAgent(KBaseAgent):
             JSON-formatted string. This might take a moment to run, as it fetches data from a database."""
             return self._get_report(process_tool_input(upa, "upa"))
 
+        @tool(args_schema=JobInput, return_direct=False)
+        def get_report_from_job_id(job_id: str) -> str:
+            """Fetch a report object from a KBase Narrative.
+            """
+            return self._get_report_from_job_id(process_tool_input(job_id, "job_id"))
+
         @tool(args_schema=UpaInput, return_direct=False)
         def get_object(upa: str) -> str:
             """Fetch a particular object from a KBase Narrative. This returns a JSON-formatted data object
@@ -64,7 +77,8 @@ class WorkspaceAgent(KBaseAgent):
             tools = [
                 list_objects,
                 get_object,
-                get_report
+                get_report,
+                get_report_from_job_id,
             ],
             llm=self._llm,
             allow_delegation=False,
@@ -95,3 +109,36 @@ class WorkspaceAgent(KBaseAgent):
         """
         ws_util = WorkspaceUtil(self._token, self._service_endpoint)
         return ws_util.get_report(upa)
+
+    def _get_report_from_job_id(self: "WorkspaceAgent", job_id: str) -> str:
+        """
+        Uses the job id to fetch a report from the workspace service.
+        This fetches the job information from the Execution Engine service first.
+        If the job is not complete, this returns a string saying so.
+        If the job is complete, but there is no report object in the output, this returns a
+        string saying so.
+        If the job is complete and has a report in its outputs, this tries to fetch
+        the report using the UPA of the report object.
+        """
+        ee = ExecutionEngine(self._token, endpoint=self.ee_endpoint)
+        state = ee.check_job(job_id)
+        if state.status in ["queued", "running"]:
+            return "The job is not yet complete"
+        if state.status in ["terminated", "error"]:
+            return "The job did not finish successfully, so there is no report to return."
+        if state.status != "completed":
+            return f"Unknown job status '{state.status}'"
+        if state.job_output is not None:
+            # look for report_ref or report_name. Maybe just name?
+            # Note: I checked out all app specs in production - report_ref and report_name are both
+            # used as "magic values" in the narrative to denote a report object. So really we just need
+            # to look for the report_ref one. They're both present in each app that makes a report.
+            # So, we need to some sifting here
+            if "result" in state.job_output and isinstance(state.job_output["result"], list):
+                if "report_ref" in state.job_output["result"][0]:
+                    return self._get_report(state.job_output["result"][0]["report_ref"])
+                else:
+                    return "No report object was found in the job results."
+            else:
+                return "The job output seems to be malformed, there is no 'result' field."
+        return "The job was completed, but no job output was found."

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -83,7 +83,7 @@ class WorkspaceUtil:
             # we need to make it look like
             # https://env.kbase.us/services/data_import_export/download?id=<shock_uuid>&wszip=0&name=<filename>
             node = url.split("/shock-api/node/")[-1]
-            url = f"{self._service_endpoint}/data_import_export/download?id={node}&wszip=0&name={report_file.name}"
+            url = f"{self._service_endpoint}blobstore/node/{node}?download"
         headers = {
             "Authorization": token
         }

--- a/narrative_llm_agent/util/workspace.py
+++ b/narrative_llm_agent/util/workspace.py
@@ -85,7 +85,7 @@ class WorkspaceUtil:
             node = url.split("/shock-api/node/")[-1]
             url = f"{self._service_endpoint}blobstore/node/{node}?download"
         headers = {
-            "Authorization": token
+            "Authorization": f"OAuth {token}"
         }
         resp = requests.get(url, headers=headers)
         try:

--- a/tests/agents/test_workspace_agent.py
+++ b/tests/agents/test_workspace_agent.py
@@ -1,9 +1,12 @@
 import json
 from narrative_llm_agent.agents.workspace import (
+    ExecutionEngine,
     Workspace,
     WorkspaceAgent,
     WorkspaceUtil
 )
+from narrative_llm_agent.kbase.clients.execution_engine import JobState
+import pytest
 
 token = "not_a_token"
 def test_init(mock_llm):
@@ -33,3 +36,52 @@ def test_get_report_tool(mock_llm, mocker):
     wa = WorkspaceAgent(token, mock_llm)
     assert wa._get_report(upa) == some_report
     mock.assert_called_once_with(upa)
+
+
+"""
+cases to cover:
+1. Bad job id
+2. x job queued
+3. x job running
+4. x job error'd
+5. x job terminated
+6. x job complete, no outputs
+7. x job complete, no report
+8. job complete, has report - happy path?
+9. job complete, report ref isn't a report
+10. x job complete, no result field
+"""
+job_id_report_cases = [
+    ("queued", None, "The job is not yet complete"),
+    ("running", None, "The job is not yet complete"),
+    ("error", None, "The job did not finish successfully, so there is no report to return."),
+    ("terminated", None, "The job did not finish successfully, so there is no report to return."),
+    ("other", None, "Unknown job status 'other'"),
+    ("completed", None, "The job was completed, but no job output was found."),
+    ("completed", {}, "The job output seems to be malformed, there is no 'result' field."),
+    ("completed", {"result": [{"stuff": "things"}]}, "No report object was found in the job results."),
+]
+@pytest.mark.parametrize("status,job_output,expected", job_id_report_cases)
+def test_get_report_from_job_id_no_report(status, job_output, expected, mock_job_states, mocker, mock_llm):
+    job_id = "job_id_1"
+    state = mock_job_states[job_id].copy()
+    state["status"] = status
+    state["job_output"] = job_output
+    mock = mocker.patch.object(ExecutionEngine, "check_job", return_value=JobState(state))
+    wa = WorkspaceAgent(token, mock_llm)
+    assert wa._get_report_from_job_id(job_id) == expected
+    mock.assert_called_once_with(job_id)
+
+def test_get_report_from_id_ok(mock_job_states, mocker, mock_llm):
+    job_id = "job_id_1"
+    some_report = "this is a report"
+    state = mock_job_states[job_id].copy()
+    report_ref = "11/22/33"
+    state["job_output"] = { "result": [{ "report_ref": report_ref }] }
+    ee_mock = mocker.patch.object(ExecutionEngine, "check_job", return_value=JobState(state))
+    ws_mock = mocker.patch.object(WorkspaceUtil, "get_report", return_value=some_report)
+    wa = WorkspaceAgent(token, mock_llm)
+    assert wa._get_report_from_job_id(job_id) == some_report
+    ee_mock.assert_called_once_with(job_id)
+    ws_mock.assert_called_once_with(report_ref)
+

--- a/tests/kbase/clients/test_workspace.py
+++ b/tests/kbase/clients/test_workspace.py
@@ -10,10 +10,10 @@ token = "not_a_token"
 endpoint = "https://nope.kbase.us/services/not_ws"
 
 @pytest.fixture
-def client():
+def ws_client():
     return Workspace(token, endpoint)
 
-def test_get_ws_info(mock_kbase_client_call, client):
+def test_get_ws_info(mock_kbase_client_call, ws_client):
     ws_id = 123
     ws_info = [
         ws_id,
@@ -26,12 +26,12 @@ def test_get_ws_info(mock_kbase_client_call, client):
         "n",
         {}
     ]
-    mock_kbase_client_call(client, ws_info)
+    mock_kbase_client_call(ws_client, ws_info)
     expected_info = WorkspaceInfo(ws_info)
-    ret_info = client.get_workspace_info(ws_id)
+    ret_info = ws_client.get_workspace_info(ws_id)
     assert str(expected_info) == str(ret_info)
 
-def test_list_workspace_objects(mock_kbase_client_call, client):
+def test_list_workspace_objects(mock_kbase_client_call, ws_client):
     """
     Need to cheat here a little bit as we're mocking two different calls.
     This would be opaque to the user, but as we're testing the client (and not mocking
@@ -44,18 +44,18 @@ def test_list_workspace_objects(mock_kbase_client_call, client):
         [2, "foo2", "Object.Type", "123", 5, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}],
         [3, "foo3", "Object.Type", "123", 6, "me", 123456, "nope", "noway", 1231234, {"some": "meta"}]
     ]
-    mock_kbase_client_call(client, ws_info, "get_workspace_info")
-    mock_kbase_client_call(client, expected_infos, "list_objects")
-    received = client.list_workspace_objects(ws_id)
+    mock_kbase_client_call(ws_client, ws_info, "get_workspace_info")
+    mock_kbase_client_call(ws_client, expected_infos, "list_objects")
+    received = ws_client.list_workspace_objects(ws_id)
     for idx, obj_info in enumerate(received):
         assert obj_info == expected_infos[idx]
 
-    received = client.list_workspace_objects(ws_id, as_dict=True)
+    received = ws_client.list_workspace_objects(ws_id, as_dict=True)
     for idx, obj_info in enumerate(received):
         assert obj_info == Workspace.obj_info_to_json(expected_infos[idx])
 
 
-def test_get_object_upas(mock_kbase_client_call, client):
+def test_get_object_upas(mock_kbase_client_call, ws_client):
     """
     Also cheating here. See test_list_workspace_objects.
     """
@@ -71,13 +71,13 @@ def test_get_object_upas(mock_kbase_client_call, client):
         WorkspaceObjectId.from_upa("123456/2/5"),
         WorkspaceObjectId.from_upa("123456/3/6")
     ]
-    mock_kbase_client_call(client, ws_info, "get_workspace_info")
-    mock_kbase_client_call(client, object_infos, "list_objects")
-    received = client.get_object_upas(ws_id)
+    mock_kbase_client_call(ws_client, ws_info, "get_workspace_info")
+    mock_kbase_client_call(ws_client, object_infos, "list_objects")
+    received = ws_client.get_object_upas(ws_id)
     for idx, upa in enumerate(received):
         assert str(upa) == str(expected[idx])
 
-def test_get_objects(mock_kbase_client_call, client):
+def test_get_objects(mock_kbase_client_call, ws_client):
     """
     #TODO this should include a mock that checks / asserts based around
     the full parameter formatting, and possibly the object result.
@@ -102,11 +102,11 @@ def test_get_objects(mock_kbase_client_call, client):
     """
     refs = ["1/2/3", "4/5/6"]
     expected_objs = [{"obj1": "stuff"}, {"obj2": "stuff"}]
-    mock_kbase_client_call(client, {"data": expected_objs})
-    assert client.get_objects(refs) == expected_objs
-    assert client.get_objects(refs, ["some/data/paths"]) == expected_objs
+    mock_kbase_client_call(ws_client, {"data": expected_objs})
+    assert ws_client.get_objects(refs) == expected_objs
+    assert ws_client.get_objects(refs, ["some/data/paths"]) == expected_objs
 
-def test_save_objects(mock_kbase_client_call, client):
+def test_save_objects(mock_kbase_client_call, ws_client):
     """
     Returns an object info in real life. For the unit test, we're kinda testing
     a no-op, ensuring that the request is well-formed and the client responds
@@ -116,8 +116,8 @@ def test_save_objects(mock_kbase_client_call, client):
     If we ever do some integration tests, that belongs there.
     """
     obj_info = [1, "foo", "bar", "123", 2, "me", 3, "nope", "noway", 1231234, {"some": "meta"}]
-    mock_kbase_client_call(client, [obj_info])
-    assert client.save_objects(3, [{"myobject": "lives_here"}]) == [obj_info]
+    mock_kbase_client_call(ws_client, [obj_info])
+    assert ws_client.save_objects(3, [{"myobject": "lives_here"}]) == [obj_info]
 
 def test_obj_info_to_json():
     obj_id = 1


### PR DESCRIPTION
Adds the get_report_from_job_id tool so the WorkspaceAgent can go straight to a report (if present) from a job id.

If there's no report or the job hasn't finished, this returns a string saying so, in a way that the LLM will be able to interpret, hopefully.