### PR TITLE
Coordinator agent

### DIFF
--- a/narrative_llm_agent/agents/coordinator.py
+++ b/narrative_llm_agent/agents/coordinator.py
@@ -1,0 +1,41 @@
+from crewai import Agent
+from narrative_llm_agent.agents.kbase_agent import KBaseAgent
+from langchain_core.language_models.llms import LLM
+
+
+class CoordinatorAgent(KBaseAgent):
+    role: str = "Project coordinator"
+    goal: str = (
+        "Ensure the seamless execution of a complex computational biology project "
+        "by coordinating the activities of all agents and ensuring they use their specialized tools effectively. "
+        "Monitor the workflow of computational biologists and support agents, "
+        "facilitate collaboration between agents, identify inefficiencies, and take corrective actions. "
+        "The ultimate goal is to ensure that all scientific objectives are met efficiently and effectively."
+    )
+    backstory: str = (
+        "The Computational Biology Project Coordinator has a rich history in managing "
+        "large-scale scientific computing projects. With a background in bioinformatics "
+        "and systems biology, The Coordinator was a key player in several groundbreaking "
+        "research initiatives that required the coordination of massive datasets and "
+        "computational resources. Known for their strategic thinking and ability to "
+        "manage complex workflows, The Coordinator has a deep understanding of the "
+        "computational tools and methods used in the field, even though they no longer "
+        "work directly with these tools. Their primary focus is ensuring that the team's "
+        "combined expertise is fully harnessed to push the boundaries of scientific discovery."
+    )
+
+    def __init__(self: "CoordinatorAgent", llm: LLM) -> None:
+        super().__init__(None, llm)
+        self.__init_agent()
+
+    def __init_agent(self: "CoordinatorAgent") -> None:
+        self.agent = Agent(
+            role = self.role,
+            goal = self.goal,
+            backstory = self.backstory,
+            tools=[],
+            verbose = True,
+            llm=self._llm,
+            allow_delegation=True,
+            memory=True,
+        )

--- a/narrative_llm_agent/agents/coordinator.py
+++ b/narrative_llm_agent/agents/coordinator.py
@@ -2,7 +2,6 @@ from crewai import Agent
 from narrative_llm_agent.agents.kbase_agent import KBaseAgent
 from langchain_core.language_models.llms import LLM
 
-
 class CoordinatorAgent(KBaseAgent):
     role: str = "Project coordinator"
     goal: str = (

--- a/tests/agents/test_coordinator_agent.py
+++ b/tests/agents/test_coordinator_agent.py
@@ -1,0 +1,16 @@
+from narrative_llm_agent.agents.coordinator import CoordinatorAgent
+import os
+import pytest
+
+FAKE_OPENAI_KEY = "fake_openai_api_key"
+FAKE_OPENAI_KEY_ENVVAR = "not_an_openai_key_environment"
+OPENAI_KEY = "OPENAI_API_KEY"
+
+@pytest.fixture(autouse=True)
+def automock_api_key(monkeypatch):
+    monkeypatch.setenv(OPENAI_KEY, FAKE_OPENAI_KEY_ENVVAR)
+
+def test_init_ok(mock_llm):
+    ca = CoordinatorAgent(mock_llm)
+    assert ca.role == "Project coordinator"
+    assert ca.agent.tools == []


### PR DESCRIPTION
Adds the Coordinator agent, which should be used as kind of an entrypoint agent. This should never have any tools, and should just invoke other agents and their tools.