### PR TITLE
migrate logic out of metadata agent

### DIFF
--- a/narrative_llm_agent/tools/narrative_tools.py
+++ b/narrative_llm_agent/tools/narrative_tools.py
@@ -1,0 +1,16 @@
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.util.narrative import NarrativeUtil
+
+
+def create_markdown_cell(
+    narrative_id: int, text: str, ws: Workspace
+) -> str:
+    """Stores results of a conversation in a Narrative markdown cell. This uses the narrative id
+    to pull the narrative from the workspace, create the new markdown cell at the bottom,
+    and save it again. It returns a simple message when complete, or throws an Exception if it
+    fails."""
+    narr_util = NarrativeUtil(ws)
+    narr = narr_util.get_narrative_from_wsid(narrative_id)
+    narr.add_markdown_cell(text)
+    narr_util.save_narrative(narr, narrative_id)
+    return "Conversation successfully stored."

--- a/narrative_llm_agent/tools/workspace_tools.py
+++ b/narrative_llm_agent/tools/workspace_tools.py
@@ -1,0 +1,9 @@
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+
+
+def get_object_metadata(obj_upa: str, ws: Workspace) -> dict[str, str]:
+    """Gets object metadata from a KBase UPA string as a dict."""
+    # look up object info first, get metadata from that to form a prompt.
+    # then have the agent converse with the user.
+    obj_info = ws.get_object_info(obj_upa)
+    return obj_info["metadata"]

--- a/tests/agents/test_metadata_agent.py
+++ b/tests/agents/test_metadata_agent.py
@@ -1,75 +1,7 @@
-from narrative_llm_agent.agents.metadata import MetadataAgent, Workspace, NarrativeUtil
-import json
-import pytest
+from narrative_llm_agent.agents.metadata import MetadataAgent
 
 token = "NotAToken"
-
-
-def mock_obj_info(upa: str, metadata: dict[str, str] | None) -> dict:
-    ws_id, obj_id, ver = upa.split("/")
-    return {
-        "ws_id": ws_id,
-        "obj_id": obj_id,
-        "name": "some_obj",
-        "ws_name": "some_ws",
-        "type": "SomeObject.Test-1.0",
-        "saved": 12345,
-        "version": ver,
-        "saved_by": "user",
-        "size_bytes": 12345,
-        "metadata": metadata,
-    }
-
-
-@pytest.fixture
-def mock_ws_client(mocker):
-    return mocker.patch("narrative_llm_agent.agents.job.Workspace")
-
 
 def test_init(mock_llm):
     ma = MetadataAgent(mock_llm, token=token)
     assert ma.role == "Human Interaction Manager"
-
-
-def test_get_obj_metadata_null(mock_llm, mocker):
-    upa = "1/2/3"
-    my_obj_info = mock_obj_info(upa, None)
-    mock = mocker.patch.object(Workspace, "get_object_info", return_value=my_obj_info)
-    ma = MetadataAgent(mock_llm, token=token)
-    assert ma._get_object_metadata(upa) == "null"
-    mock.assert_called_once_with(upa)
-
-
-def test_get_obj_metadata(mock_llm, mocker):
-    upa = "1/2/3"
-    meta = {"foo": "bar", "baz": "frobozz"}
-    my_obj_info = mock_obj_info(upa, meta)
-    mock = mocker.patch.object(Workspace, "get_object_info", return_value=my_obj_info)
-    ma = MetadataAgent(mock_llm, token=token)
-    meta_str = ma._get_object_metadata(upa)
-    assert json.loads(meta_str) == meta
-    mock.assert_called_once_with(upa)
-
-
-# TODO: tests for errors, bad upas, missing data, not allowed, etc.
-
-
-def test_store_conversation(mock_llm, mocker, test_narrative_object):
-    ws_id = 123
-    conversation = json.dumps({"some": "chat", "results": "here"})
-    narr = test_narrative_object
-    get_mock = mocker.patch.object(
-        NarrativeUtil, "get_narrative_from_wsid", return_value=narr
-    )
-    save_mock = mocker.patch.object(NarrativeUtil, "save_narrative", return_value=[])
-    num_cells = len(narr.cells)
-    ma = MetadataAgent(mock_llm, token=token)
-    resp = ma._store_conversation(ws_id, conversation)
-    assert resp == "Conversation successfully stored."
-    get_mock.assert_called_once_with(ws_id)
-    save_mock.assert_called_once_with(narr, ws_id)
-    assert len(narr.cells) == num_cells + 1
-    assert narr.cells[-1].source == conversation
-
-
-# TODO: tests for errors, bad ws_id, non-string conversations

--- a/tests/tools/test_narrative_tools.py
+++ b/tests/tools/test_narrative_tools.py
@@ -1,0 +1,22 @@
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.tools.narrative_tools import create_markdown_cell
+from narrative_llm_agent.util.narrative import NarrativeUtil
+
+
+def test_create_markdown_cell(mocker, test_narrative_object):
+    ws_id = 123
+    conversation = "This is very important."
+    narr = test_narrative_object
+    get_mock = mocker.patch.object(
+        NarrativeUtil, "get_narrative_from_wsid", return_value=narr
+    )
+    save_mock = mocker.patch.object(NarrativeUtil, "save_narrative", return_value=[])
+    num_cells = len(narr.cells)
+    resp = create_markdown_cell(ws_id, conversation, mocker.Mock(spec=Workspace))
+    assert resp == "Conversation successfully stored."
+    get_mock.assert_called_once_with(ws_id)
+    save_mock.assert_called_once_with(narr, ws_id)
+    assert len(narr.cells) == num_cells + 1
+    assert narr.cells[-1].source == conversation
+
+

--- a/tests/tools/test_workspace_tools.py
+++ b/tests/tools/test_workspace_tools.py
@@ -1,0 +1,40 @@
+
+from pytest_mock import MockerFixture
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.tools.workspace_tools import get_object_metadata
+
+
+def mock_obj_info(upa: str, metadata: dict[str, str] | None) -> dict:
+    ws_id, obj_id, ver = upa.split("/")
+    return {
+        "ws_id": ws_id,
+        "obj_id": obj_id,
+        "name": "some_obj",
+        "ws_name": "some_ws",
+        "type": "SomeObject.Test-1.0",
+        "saved": 12345,
+        "version": ver,
+        "saved_by": "user",
+        "size_bytes": 12345,
+        "metadata": metadata,
+    }
+
+def build_mock_ws(mocker: MockerFixture, upa: str, meta: dict[str|str] | None):
+    my_obj_info = mock_obj_info(upa, meta)
+    mock_ws = mocker.Mock(spec=Workspace)
+    mock_ws.get_object_info.return_value = my_obj_info
+    return mock_ws
+
+
+def test_get_obj_metadata_null(mocker: MockerFixture):
+    upa = "1/2/3"
+    assert get_object_metadata(upa, build_mock_ws(mocker, upa, None)) is None
+
+
+def test_get_obj_metadata(mocker: MockerFixture):
+    upa = "1/2/3"
+    meta = {"foo": "bar", "baz": "frobozz"}
+    meta_result = get_object_metadata(upa, build_mock_ws(mocker, upa, meta))
+    assert meta_result == meta
+
+# TODO: tests for errors, bad upas, missing data, not allowed, etc.


### PR DESCRIPTION
Next one, migrate tool code out of the metadata agent.