### PR TITLE
make the SPIN userid a real userid in the image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -37,5 +37,10 @@ WORKDIR /app/narrative_llm_agent/user_interface
 # Expose the port the app runs on
 EXPOSE 8501
 
+RUN mkdir -p /home/agent_runner && \
+    useradd agent_runner -u96921 -d/home/agent_runner && \
+    chown 96921 /home/agent_runner
+
+
 # Command to run the app
 CMD ["poetry", "run", "streamlit", "run", "genome_annotation_pipeline_streamlit.py"]


### PR DESCRIPTION
This was the error causing the image to fail when deployed on SPIN. CrewAI wanted a place to store intermediate data, it goes with `~/.local/share`. If that's not around, or unwriteable, it fails.

The solution here is to make the SPIN user id (always set) a real user with a real home directory.