### PR TITLE
Combine app tasks

### DIFF
--- a/narrative_llm_agent/agents/job.py
+++ b/narrative_llm_agent/agents/job.py
@@ -1,14 +1,10 @@
 from typing import Any, Optional
-from narrative_llm_agent.kbase.clients.blobstore import Blobstore
 from narrative_llm_agent.tools.app_tools import get_app_params
 from narrative_llm_agent.tools.job_tools import (
     CompletedJob,
     get_job_status,
-    monitor_job,
-    start_job,
     run_job
 )
-from narrative_llm_agent.tools.report_tools import get_report
 from .kbase_agent import KBaseAgent
 from crewai import Agent
 from langchain_core.language_models.llms import LLM
@@ -90,26 +86,6 @@ class JobAgent(KBaseAgent):
             """
             return get_job_status(process_tool_input(job_id, "job_id"), ExecutionEngine(token=self._token))
 
-        # @tool("start job")
-        # def start_job_tool(narrative_id: int, app_id: str, params: dict) -> str:
-        #     """This starts a new job in KBase, running the given App with the given
-        #     parameters in the given Narrative. If the app with app_id doesn't exist, this
-        #     raises a AppNotFound error. If the narrative_id doesn't exist, or the user
-        #     doesn't have write access to it, this raises a PermissionsError. If the
-        #     parameters are malformed, or refer to data objects that do not exist, this
-        #     returns a ValueError. If the app starts, this returns a JSON-formatted
-        #     dictionary with cell_id and job_id fields."""
-
-        #     if isinstance(params, str):
-        #         params = json.loads(params)
-        #     return start_job(
-        #         process_tool_input(narrative_id, "narrative_id"),
-        #         process_tool_input(app_id, "app_id"),
-        #         params,
-        #         ExecutionEngine(token=self._token),
-        #         NarrativeMethodStore(),
-        #         Workspace(token=self._token),
-        #     )
 
         @tool("get app parameters")
         def get_app_params_tool(app_id: str) -> str:
@@ -119,19 +95,6 @@ class JobAgent(KBaseAgent):
             an AppNotFound error.
             """
             return json.dumps(get_app_params(app_id, NarrativeMethodStore()))
-
-        # @tool("monitor job")
-        # def monitor_job_tool(job_id: str) -> CompletedJob:
-        #     """
-        #     This monitors a running job in KBase. It will check the job status every 10 seconds.
-        #     When complete, this returns the final job status as a JSON-formatted string. The
-        #     final state can be either completed or error. This might take some time to run,
-        #     as it depends on the job that is running.
-        #     """
-        #     ee = ExecutionEngine(token=self._token)
-        #     nms = NarrativeMethodStore()
-        #     ws = Workspace(token=self._token)
-        #     return monitor_job(process_tool_input(job_id, "job_id"), ee, nms, ws)
 
         @tool("run job")
         def run_job_tool(narrative_id: int, app_id: str, params: dict) -> CompletedJob:
@@ -159,9 +122,7 @@ class JobAgent(KBaseAgent):
             verbose=True,
             tools=[
                 get_job_status_tool,
-                # start_job_tool,
                 get_app_params_tool,
-                # monitor_job_tool,
                 run_job_tool,
             ],  # + human_tools,
             llm=self._llm,

--- a/narrative_llm_agent/agents/job.py
+++ b/narrative_llm_agent/agents/job.py
@@ -100,9 +100,9 @@ class JobAgent(KBaseAgent):
         def run_job_tool(narrative_id: int, app_id: str, params: dict) -> CompletedJob:
             """
             This starts and runs a job in KBase. Once the job starts, it checks the status
-            every 10 seconds. When complete, this returns the final job status as a JSON-formatted
-            string. The final state can be either completed or error. This might take some time
-            to run, as it depends on the job that is running.
+            every 10 seconds. When complete, this returns the job information including
+            the final status, list of any created objects, and report UPA.
+            This might take some time to run, as it depends on the job that is running.
             """
             if isinstance(params, str):
                 params = json.loads(params)

--- a/narrative_llm_agent/agents/job.py
+++ b/narrative_llm_agent/agents/job.py
@@ -1,11 +1,14 @@
 from typing import Any, Optional
+from narrative_llm_agent.kbase.clients.blobstore import Blobstore
 from narrative_llm_agent.tools.app_tools import get_app_params
 from narrative_llm_agent.tools.job_tools import (
     CompletedJob,
     get_job_status,
     monitor_job,
     start_job,
+    run_job
 )
+from narrative_llm_agent.tools.report_tools import get_report
 from .kbase_agent import KBaseAgent
 from crewai import Agent
 from langchain_core.language_models.llms import LLM
@@ -59,6 +62,10 @@ class AppOutputInfo(BaseModel):
     narrative_id: int
 
 
+class CompletedJobAndReport(BaseModel):
+    job_info: CompletedJob
+    report: Optional[str] = None
+
 class JobAgent(KBaseAgent):
     role: str = "Job and App Manager"
     goal: str = """Manage app and job running and tracking in the KBase system.
@@ -83,26 +90,26 @@ class JobAgent(KBaseAgent):
             """
             return get_job_status(process_tool_input(job_id, "job_id"), ExecutionEngine(token=self._token))
 
-        @tool("start job")
-        def start_job_tool(narrative_id: int, app_id: str, params: dict) -> str:
-            """This starts a new job in KBase, running the given App with the given
-            parameters in the given Narrative. If the app with app_id doesn't exist, this
-            raises a AppNotFound error. If the narrative_id doesn't exist, or the user
-            doesn't have write access to it, this raises a PermissionsError. If the
-            parameters are malformed, or refer to data objects that do not exist, this
-            returns a ValueError. If the app starts, this returns a JSON-formatted
-            dictionary with cell_id and job_id fields."""
+        # @tool("start job")
+        # def start_job_tool(narrative_id: int, app_id: str, params: dict) -> str:
+        #     """This starts a new job in KBase, running the given App with the given
+        #     parameters in the given Narrative. If the app with app_id doesn't exist, this
+        #     raises a AppNotFound error. If the narrative_id doesn't exist, or the user
+        #     doesn't have write access to it, this raises a PermissionsError. If the
+        #     parameters are malformed, or refer to data objects that do not exist, this
+        #     returns a ValueError. If the app starts, this returns a JSON-formatted
+        #     dictionary with cell_id and job_id fields."""
 
-            if isinstance(params, str):
-                params = json.loads(params)
-            return start_job(
-                process_tool_input(narrative_id, "narrative_id"),
-                process_tool_input(app_id, "app_id"),
-                params,
-                ExecutionEngine(token=self._token),
-                NarrativeMethodStore(),
-                Workspace(token=self._token),
-            )
+        #     if isinstance(params, str):
+        #         params = json.loads(params)
+        #     return start_job(
+        #         process_tool_input(narrative_id, "narrative_id"),
+        #         process_tool_input(app_id, "app_id"),
+        #         params,
+        #         ExecutionEngine(token=self._token),
+        #         NarrativeMethodStore(),
+        #         Workspace(token=self._token),
+        #     )
 
         @tool("get app parameters")
         def get_app_params_tool(app_id: str) -> str:
@@ -113,18 +120,37 @@ class JobAgent(KBaseAgent):
             """
             return json.dumps(get_app_params(app_id, NarrativeMethodStore()))
 
-        @tool("monitor job")
-        def monitor_job_tool(job_id: str) -> CompletedJob:
+        # @tool("monitor job")
+        # def monitor_job_tool(job_id: str) -> CompletedJob:
+        #     """
+        #     This monitors a running job in KBase. It will check the job status every 10 seconds.
+        #     When complete, this returns the final job status as a JSON-formatted string. The
+        #     final state can be either completed or error. This might take some time to run,
+        #     as it depends on the job that is running.
+        #     """
+        #     ee = ExecutionEngine(token=self._token)
+        #     nms = NarrativeMethodStore()
+        #     ws = Workspace(token=self._token)
+        #     return monitor_job(process_tool_input(job_id, "job_id"), ee, nms, ws)
+
+        @tool("run job")
+        def run_job_tool(narrative_id: int, app_id: str, params: dict) -> CompletedJob:
             """
-            This monitors a running job in KBase. It will check the job status every 10 seconds.
-            When complete, this returns the final job status as a JSON-formatted string. The
-            final state can be either completed or error. This might take some time to run,
-            as it depends on the job that is running.
+            This starts and runs a job in KBase. Once the job starts, it checks the status
+            every 10 seconds. When complete, this returns the final job status as a JSON-formatted
+            string. The final state can be either completed or error. This might take some time
+            to run, as it depends on the job that is running.
             """
-            ee = ExecutionEngine(token=self._token)
-            nms = NarrativeMethodStore()
-            ws = Workspace(token=self._token)
-            return monitor_job(process_tool_input(job_id, "job_id"), ee, nms, ws)
+            if isinstance(params, str):
+                params = json.loads(params)
+            return run_job(
+                process_tool_input(narrative_id, "narrative_id"),
+                process_tool_input(app_id, "app_id"),
+                params,
+                ExecutionEngine(token=self._token),
+                NarrativeMethodStore(),
+                Workspace(token=self._token),
+            )
 
         self.agent = Agent(
             role=self.role,
@@ -133,9 +159,10 @@ class JobAgent(KBaseAgent):
             verbose=True,
             tools=[
                 get_job_status_tool,
-                start_job_tool,
+                # start_job_tool,
                 get_app_params_tool,
-                monitor_job_tool,
+                # monitor_job_tool,
+                run_job_tool,
             ],  # + human_tools,
             llm=self._llm,
             allow_delegation=False,

--- a/narrative_llm_agent/crews/job_crew.py
+++ b/narrative_llm_agent/crews/job_crew.py
@@ -169,54 +169,8 @@ class JobCrew:
             context=[get_app_params_task],
         )
 
-        # start_job_task = Task(
-        #     name=f"2. Start running {app_name}",
-        #     description=f"""
-        #     Using the app parameters and app id, use provided tools to start a new KBase app, which will return a job id.
-        #     Use that job id to create a new App Cell in the narrative such that narrative_id={narrative_id}. Return only the
-        #     job id.
-        #     """,
-        #     expected_output="A KBase job id string.",
-        #     agent=self._job.agent,
-        #     context=[get_app_params_task],
-        # )
-
-        # make_app_cell_task = Task(
-        #     name=f"3. Make app cell for {app_name}",
-        #     description=f"""
-        #     Using the job id, create an app cell in narrative {narrative_id}. The add_app_cell tool is useful here.
-        #     """,
-        #     expected_output="A note with either success or failure of saving the new cell",
-        #     agent=self._narr.agent,
-        # )
-
-        # monitor_job_task = Task(
-        #     name=f"4. Monitor the running {app_name} job",
-        #     description="""
-        #     Use the `monitor_job` tool with the job id to monitor the progress of the running job.
-
-        #     This tool returns a `CompletedJob` object that contains the job's output UPA and the output object name.
-
-        #     - If the job is in an error state, the tool will indicate this in the job_error field.
-        #     - Your job is to call the tool, and return its result directly — do not modify the structure or add commentary.
-        #     - This output will be passed to the next task to retrieve the job's report.
-
-        #     The result must be returned exactly as provided by the tool.
-        #     """,
-        #     expected_output="The CompletedJob object returned by the monitor_job tool.",
-
-        #     # description="""
-        #     # Using the job id, monitor the progress of the running job. The monitor_job tool is helpful here.
-        #     # If completed, continue to the next task. If in an error state, summarize the error for the user and stop.
-        #     # """,
-        #     # expected_output="Return either a note saying that the job has completed, or a summary of the job error.",
-            # output_pydantic=CompletedJob,
-            # agent=self._job.agent,
-            # context=[start_job_task],
-        # )
-
         report_retrieval_task = Task(
-            name=f"5. Retrieve the report for the finished {app_name} job",
+            name=f"3. Retrieve the report for the finished {app_name} job",
             description="""
                 You have received a `CompletedJob` object from the previous task. Use its `report_upa` field to locate the report UPA in the Workspace.
 
@@ -227,20 +181,13 @@ class JobCrew:
                 If no report is found, or the UPA is invalid, return a string indicating so.
             """,
 
-            # description="""Get the report UPA from the job results (a string with format number/number/number), an
-            # use a tool to get the report object from the Workspace service. UPAs are unique permanent addresses used to identify data objects.
-            # The Workspace Manager will be helpful here. Make sure the delegated agent uses a tool for interacting with KBase.
-            # If there was an error in the job results, return a string saying so and summarizing the error.
-            # If no report is available, either because there is no report UPA or the report object is unavailable, return a string saying so.
-            # Otherwise, return the full report text. Your final answer MUST be the report text.
-            # """,
             expected_output="The text of a KBase app report object",
             agent=self._workspace.agent,
             context=[start_job_task]
         )
 
         report_analysis_task = Task(
-            name=f"6. Analyze the report from the {app_name} job",
+            name=f"4. Analyze the report from the {app_name} job",
             description=
             """Analyze the given report and derive some biological insight into the result.
             If the report is not in JSON format, then interpret the document as-is.
@@ -265,7 +212,7 @@ class JobCrew:
         )
 
         save_analysis_task = Task(
-            name=f"7. Save the report analysis for {app_name} as markdown",
+            name=f"5. Save the report analysis for {app_name} as markdown",
             description=f"""Save the analysis by adding a markdown cell to the Narrative with id {narrative_id}. The markdown text must
             be the analysis text. If not successful, say so and stop. If an output object was created, ensure that it has both an UPA and name.
             In the end, return the results of the job completion task with both UPA and name for output object. The return result must be normalized to contain
@@ -281,8 +228,6 @@ class JobCrew:
         return [
             get_app_params_task,
             start_job_task,
-            # make_app_cell_task,
-            # monitor_job_task,
             report_retrieval_task,
             report_analysis_task,
             save_analysis_task,

--- a/narrative_llm_agent/crews/job_crew.py
+++ b/narrative_llm_agent/crews/job_crew.py
@@ -1,4 +1,4 @@
-from narrative_llm_agent.agents.job import JobAgent, AppStartInfo
+from narrative_llm_agent.agents.job import CompletedJobAndReport, JobAgent, AppStartInfo
 from narrative_llm_agent.agents.narrative import NarrativeAgent
 from narrative_llm_agent.agents.workspace import WorkspaceAgent
 from narrative_llm_agent.agents.coordinator import CoordinatorAgent
@@ -151,55 +151,74 @@ class JobCrew:
         )
 
         start_job_task = Task(
-            name=f"2. Start running {app_name}",
+            name=f"2. Run app {app_name}",
             description=f"""
-            Using the app parameters and app id, use provided tools to start a new KBase app, which will return a job id.
-            Use that job id to create a new App Cell in the narrative such that narrative_id={narrative_id}. Return only the
-            job id.
+            Using the app parameters, app id, and narrative id {narrative_id}, use the `run_job` tool to run a new KBase app. This will run
+            the app and return a `CompletedJobAndReport` object that contains the output from the job and a report from the app, if
+            applicable.
+
+            - If the job is in an error state, the tool will indicate this in the job_error field.
+            - Your job is to call the tool, and return its result directly — do not modify the structure or add commentary.
+            - This output will be passed to the next task to interpret the job's report.
+
+            The result must be returned exactly as provided by the tool.
             """,
-            expected_output="A KBase job id string.",
+            expected_output="The CompletedJobAndReport object returned by the monitor_job tool.",
+            output_pydantic=CompletedJob,
             agent=self._job.agent,
             context=[get_app_params_task],
         )
 
-        make_app_cell_task = Task(
-            name=f"3. Make app cell for {app_name}",
-            description=f"""
-            Using the job id, create an app cell in narrative {narrative_id}. The add_app_cell tool is useful here.
-            """,
-            expected_output="A note with either success or failure of saving the new cell",
-            agent=self._narr.agent,
-        )
+        # start_job_task = Task(
+        #     name=f"2. Start running {app_name}",
+        #     description=f"""
+        #     Using the app parameters and app id, use provided tools to start a new KBase app, which will return a job id.
+        #     Use that job id to create a new App Cell in the narrative such that narrative_id={narrative_id}. Return only the
+        #     job id.
+        #     """,
+        #     expected_output="A KBase job id string.",
+        #     agent=self._job.agent,
+        #     context=[get_app_params_task],
+        # )
 
-        monitor_job_task = Task(
-            name=f"4. Monitor the running {app_name} job",
-            description="""
-            Use the `monitor_job` tool with the job id to monitor the progress of the running job.
+        # make_app_cell_task = Task(
+        #     name=f"3. Make app cell for {app_name}",
+        #     description=f"""
+        #     Using the job id, create an app cell in narrative {narrative_id}. The add_app_cell tool is useful here.
+        #     """,
+        #     expected_output="A note with either success or failure of saving the new cell",
+        #     agent=self._narr.agent,
+        # )
 
-            This tool returns a `CompletedJob` object that contains the job's output UPA and the output object name.
+        # monitor_job_task = Task(
+        #     name=f"4. Monitor the running {app_name} job",
+        #     description="""
+        #     Use the `monitor_job` tool with the job id to monitor the progress of the running job.
 
-            - If the job is in an error state, the tool will indicate this in the job_error field.
-            - Your job is to call the tool, and return its result directly — do not modify the structure or add commentary.
-            - This output will be passed to the next task to retrieve the job's report.
+        #     This tool returns a `CompletedJob` object that contains the job's output UPA and the output object name.
 
-            The result must be returned exactly as provided by the tool.
-            """,
-            expected_output="The CompletedJob object returned by the monitor_job tool.",
+        #     - If the job is in an error state, the tool will indicate this in the job_error field.
+        #     - Your job is to call the tool, and return its result directly — do not modify the structure or add commentary.
+        #     - This output will be passed to the next task to retrieve the job's report.
 
-            # description="""
-            # Using the job id, monitor the progress of the running job. The monitor_job tool is helpful here.
-            # If completed, continue to the next task. If in an error state, summarize the error for the user and stop.
-            # """,
-            # expected_output="Return either a note saying that the job has completed, or a summary of the job error.",
-            output_pydantic=CompletedJob,
-            agent=self._job.agent,
-            context=[start_job_task],
-        )
+        #     The result must be returned exactly as provided by the tool.
+        #     """,
+        #     expected_output="The CompletedJob object returned by the monitor_job tool.",
+
+        #     # description="""
+        #     # Using the job id, monitor the progress of the running job. The monitor_job tool is helpful here.
+        #     # If completed, continue to the next task. If in an error state, summarize the error for the user and stop.
+        #     # """,
+        #     # expected_output="Return either a note saying that the job has completed, or a summary of the job error.",
+            # output_pydantic=CompletedJob,
+            # agent=self._job.agent,
+            # context=[start_job_task],
+        # )
 
         report_retrieval_task = Task(
             name=f"5. Retrieve the report for the finished {app_name} job",
             description="""
-                You have received a `CompletedJob` object from the previous task. Use its `upa` field to locate the report UPA in the Workspace.
+                You have received a `CompletedJob` object from the previous task. Use its `report_upa` field to locate the report UPA in the Workspace.
 
                 - If `report_upa` is None, return a string indicating that no report is available due to an error.
                 - Otherwise, use the UPA to retrieve the corresponding report object from the Workspace.
@@ -217,7 +236,7 @@ class JobCrew:
             # """,
             expected_output="The text of a KBase app report object",
             agent=self._workspace.agent,
-            context=[monitor_job_task]
+            context=[start_job_task]
         )
 
         report_analysis_task = Task(
@@ -256,14 +275,14 @@ class JobCrew:
             output_pydantic=CompletedJob,
             agent=self._narr.agent,
             extra_content=narrative_id,
-            context=[monitor_job_task, report_analysis_task],
+            context=[start_job_task, report_analysis_task],
         )
 
         return [
             get_app_params_task,
             start_job_task,
-            make_app_cell_task,
-            monitor_job_task,
+            # make_app_cell_task,
+            # monitor_job_task,
             report_retrieval_task,
             report_analysis_task,
             save_analysis_task,

--- a/narrative_llm_agent/tools/job_tools.py
+++ b/narrative_llm_agent/tools/job_tools.py
@@ -39,14 +39,21 @@ def summarize_completed_job(
 ) -> CompletedJob:
     """
     This summarizes a completed job with the following information:
+    * The narrative id
+    * The final job status
+    * The job id
     * The report object UPA, if any
     * A list of created objects, if any, including their names and UPAs.
     This currently searches the list of Created Objects from the given report
     (if any), and the app parameters for any output objects. So it's really
     up to the app authors to play nicely and populate those things correctly.
+    * Job errors, if any
 
     TODO: Also consider searching the workspace for recently made objects,
     relative to when the app was completed.
+    TODO: If the job has errors, the report UPA and created objects should
+    probably be empty. "Completed with errors" is a possibility, but I don't
+    think many KBase apps support that.
     """
     # get the output
     # get the report object

--- a/narrative_llm_agent/tools/job_tools.py
+++ b/narrative_llm_agent/tools/job_tools.py
@@ -169,6 +169,10 @@ def run_job(
     nms: NarrativeMethodStore,
     ws: Workspace
 ) -> CompletedJob:
+    """
+    Runs a job from end to end. Starts it, creates an app cell for it, monitors the job, and returns
+    the CompletedJob object at the end.
+    """
     job_id = start_job(narrative_id, app_id, params, ee, nms, ws)
     # TODO have this return an error state as well, for checking. Right now, just letting exceptions go up.
     create_app_cell(

--- a/narrative_llm_agent/tools/narrative_tools.py
+++ b/narrative_llm_agent/tools/narrative_tools.py
@@ -69,6 +69,7 @@ def create_app_cell(
     up all the app information required to rebuild an app cell. It adds the cell to the
     bottom of the narrative in the state it was in during the last check. If successful,
     this returns the string 'success'.
+    TODO: This should raise a better exception, or return an error string, if something fails.
     """
     job_state = ee.check_job(job_id)
     app_spec = nms.get_app_spec(job_state.job_input.app_id)

--- a/narrative_llm_agent/util/app.py
+++ b/narrative_llm_agent/util/app.py
@@ -143,11 +143,12 @@ def get_ws_object_refs(app_spec: AppSpec, params: dict) -> list:
     ws_objects = []
     for param in spec_params.values():
         if param["type"] == "data_object" and not param["is_output_object"]:
-            param_value = params[param["id"]]
-            if isinstance(param_value, list):
-                ws_objects += param_value
-            else:
-                ws_objects.append(param_value)
+            param_value = params.get(param["id"])
+            if param_value is not None:
+                if isinstance(param_value, list):
+                    ws_objects += param_value
+                else:
+                    ws_objects.append(param_value)
     return ws_objects
 
 

--- a/tests/tools/test_job_tools.py
+++ b/tests/tools/test_job_tools.py
@@ -10,6 +10,7 @@ from narrative_llm_agent.tools.job_tools import (
     CompletedJob,
     monitor_job,
     start_job,
+    run_job,
     summarize_completed_job,
     get_job_status,
 )
@@ -19,7 +20,7 @@ from narrative_llm_agent.kbase.clients.narrative_method_store import (
     NarrativeMethodStore,
 )
 import pytest
-from tests.test_data.test_data import load_test_data_json
+from tests.test_data.test_data import get_test_narrative, load_test_data_json
 
 
 @pytest.fixture
@@ -84,6 +85,21 @@ def test_summarize_completed_job_ok(mock_workspace, mock_nms):
         CreatedObject(object_upa="1000/5/1", object_name="new_genome")
     ]
 
+
+def test_get_app_created_objects():
+    # TODO test this with the following cases
+    # 1. happy path, simple app spec, input params -> service params with same id
+    # 2. tricky path, app spec with input params -> service params with different id
+    # 3. single input param -> multiple service params (unlikely in practice, but allowed by spec)
+    #    should do a single lookup, since name is identical
+    # 4. no output objects
+    # 5. output object name is null / None
+    # 6. fail / unhappy paths
+    #    - missing object name
+    #    - missing parameter value
+    #    - network failure
+    #    - no output objects
+    pass
 
 def test_job_status_tool(
     mock_kbase_jsonrpc_1_call: Callable,
@@ -150,7 +166,7 @@ def test_start_job_tool(app_spec: AppSpec, mocker: MockerFixture):
 
     mock_ws = mocker.Mock(spec=Workspace)
     mock_ws.get_workspace_info.return_value = WorkspaceInfo(
-        [1000, "test_workspace", "test_user", "12345", 100, "a", "n", "n", {}]
+        [narrative_id, "test_workspace", "test_user", "12345", 100, "a", "n", "n", {}]
     )
     mock_ws.get_object_info.return_value = Workspace.obj_info_to_json(
         [
@@ -168,3 +184,108 @@ def test_start_job_tool(app_spec: AppSpec, mocker: MockerFixture):
         ]
     )
     assert start_job(narrative_id, app_id, params, mock_ee, mock_nms, mock_ws) == job_id
+
+
+def test_run_job_tool(app_spec: AppSpec, mocker: MockerFixture):
+    job_id = "fake_job_id"
+    narr_id = 1000
+    app_id = "FakeModule/fake_app"
+    params = {
+        "actual_input_object": f"{narr_id}/2/3",
+        "actual_output_object": "NewGenomeObject",
+    }
+
+    mock_ee = mocker.Mock(spec=ExecutionEngine)
+    mock_ee.run_job.return_value = job_id
+
+    js_dict = {
+        "job_id": job_id,
+        "user": "some_user",
+        "status": "completed",
+        "job_output": {
+            "version": "1.1",
+            "result": [{
+                "report_ref": f"{narr_id}/6/1",
+                "report_name": "some_app_report",
+                "actual_output_object": "NewGenomeObject"
+            }],
+            "id": "12345",
+        },
+        "wsid": narr_id,
+        "created": 1740073655000,
+        "queued": 1740073656144,
+        "running": 1740073667463,
+        "finished": 1740073793172,
+        "job_input": {
+            "method": "fake_app.run_fake_app",
+            "app_id": app_id,
+            "params": [
+                {
+                    "workspace": narr_id,
+                    "input_genome_name": f"{narr_id}/2/3",
+                    "output_genome_name": "NewGenomeObject"
+                }
+            ],
+            "source_ws_objects": [f"{narr_id}/4/1"],
+            "meta": {},
+            "ws_id": narr_id,
+            "narrative_cell_info": {
+                "cell_id": "f51528ba-0912-4b3a-abde-1154896bcde7",
+                "run_id": "047f3969-ff35-447e-afee-fefa1cbbdc2e",
+                "app_version_tag": "release",
+            },
+            "service_ver": "332506c1b0b98d7f3589779c94e187019883ab66",
+        },
+    }
+    job_state = JobState(js_dict)
+    mock_ee.check_job.return_value = job_state # fake job state
+
+    mock_nms = mocker.Mock(spec=NarrativeMethodStore)
+    mock_nms.get_app_spec.return_value = app_spec.model_dump()
+
+    mock_ws = mocker.Mock(spec=Workspace)
+    mock_ws.get_workspace_info.return_value = WorkspaceInfo(
+        [narr_id, "test_workspace", "test_user", "12345", 100, "a", "n", "n", {"narrative": "1"}]
+    )
+    mock_ws.get_object_info.return_value = Workspace.obj_info_to_json(
+        [
+            5,
+            "NewGenomeObject",
+            "KBaseGenomes.Genome-1.0",
+            "2024-02-02T17:55:23+0000",
+            1,
+            "me",
+            narr_id,
+            "my_narrative",
+            "768202029fa4440b217d6c7a41a27a58",
+            1089,
+            {},
+        ]
+    )
+    narr_obj_info = [
+        1,
+        "my_narrative",
+        "KBaseNarrative.Narrative-4.0",
+        "2024-02-02T17:55:23+0000",
+        narr_id,
+        "me",
+        1,
+        "my_narrative",
+        "768202029fa4440b217d6c7a41a27a58",
+        1089,
+    ]
+    mock_ws.get_objects.return_value = [{
+        "info": narr_obj_info,
+        "data": get_test_narrative(as_dict=True)
+    }]
+    mock_ws.save_objects.return_value = [narr_obj_info]
+
+    job_result = run_job(narr_id, app_id, params, mock_ee, mock_nms, mock_ws)
+    assert isinstance(job_result, CompletedJob)
+    assert job_result.job_error is None
+    assert job_result.job_id == job_state.job_id
+    assert job_result.job_status == job_state.status
+    assert job_result.report_upa == f"{narr_id}/6/1"
+    assert job_result.created_objects == [
+        CreatedObject(object_upa=f"{narr_id}/5/1", object_name="NewGenomeObject")
+    ]

--- a/tests/tools/test_job_tools.py
+++ b/tests/tools/test_job_tools.py
@@ -85,6 +85,10 @@ def test_summarize_completed_job_ok(mock_workspace, mock_nms):
         CreatedObject(object_upa="1000/5/1", object_name="new_genome")
     ]
 
+# TODO - testing summarize_completed_job
+# 1. ends with error - should just have error, no created objects or report ref, etc.
+# 2. mock network fails, call failures
+
 
 def test_get_app_created_objects():
     # TODO test this with the following cases


### PR DESCRIPTION
Combines the "start job", "create app cell", and "monitor job" tasks into a single one that does all of that and returns the CompletedJob object at the end.

I tried to add in the report fetching step, but that made a confusing data structure (that seemed to break token limits and caused timeouts). So, leaving that out for now.