### PR TITLE
first step on getting narrative objects in dropdown

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -5,6 +5,7 @@ execution_engine=ee2
 narrative_method_store=narrative_method_store/rpc
 blobstore=blobstore
 auth=auth
+search=searchapi2/rpc
 cborg_api_endpoint=https://api.cborg.lbl.gov/
 openai_api_endpoint=https://api.openai.com/
 auth_token_env=KB_AUTH_TOKEN

--- a/narrative_llm_agent/config.py
+++ b/narrative_llm_agent/config.py
@@ -54,6 +54,8 @@ class AgentConfig:
                 self.blobstore_endpoint = self.service_endpoint + kb_cfg["blobstore"]
             if "auth" in kb_cfg:
                 self.auth_endpoint = self.service_endpoint + kb_cfg["auth"]
+            if "search" in kb_cfg:
+                self.search_endpoint = self.service_endpoint + kb_cfg["search"]
         self.cborg_api_endpoint = kb_cfg.get("cborg_api_endpoint")
         self.openai_api_endpoint = kb_cfg.get("openai_api_endpoint")
 

--- a/narrative_llm_agent/kbase/clients/search.py
+++ b/narrative_llm_agent/kbase/clients/search.py
@@ -1,0 +1,64 @@
+from typing import List
+from narrative_llm_agent.kbase.service_client import ServiceClient
+from narrative_llm_agent.config import get_config
+from pydantic import BaseModel
+
+class DataObject(BaseModel):
+  name: str
+  obj_type: str
+
+
+class NarrativeDocCell(BaseModel):
+    desc: str
+    cell_type: str
+
+
+class NarrativeDoc(BaseModel):
+    access_group: int
+    cells: List[NarrativeDocCell]
+    copied: bool | None
+    creation_date: str
+    creator: str
+    data_objects: List[DataObject]
+    is_narratorial: bool
+    is_public: bool
+    modified_at: int
+    narrative_title: str
+    obj_id: int
+    obj_name: str
+    obj_type_module: str
+    obj_type_version: str
+    owner: str
+    shared_users: list[str]
+    tags: list[str]
+    timestamp: int
+    total_cells: int
+    version: int
+
+
+class NarrativeSearchResults(BaseModel):
+    count: int
+    search_time: int
+    hits: List[NarrativeDoc]
+
+
+class Search(ServiceClient):
+    _service = "search"
+    def __init__(self, endpoint: str = None, token: str = None) -> None:
+        if endpoint is None:
+            endpoint = get_config().search_endpoint
+        super().__init__(endpoint, self._service, token=token)
+
+    def search_narratives(self, owner: str, query: str = None) -> NarrativeSearchResults:
+        params = {
+            "access": {"only_public": False},
+            "filters": {"operator": "AND", "fields": [{"field": "owner", "term": owner}]},
+            "paging": {"length": 20, "offset": 0},
+            "sorts": [["timestamp", "desc"], ["_score", "desc"]],
+            "types": ["KBaseNarrative.Narrative"]
+        }
+
+        if query is not None:
+            params["search"] = {"query": query, "fields": ["agg_fields"]}
+        results = self.make_kbase_jsonrpc_1_call("search_workspace", params)
+        return NarrativeSearchResults.model_validate(results)

--- a/narrative_llm_agent/kbase/service_client.py
+++ b/narrative_llm_agent/kbase/service_client.py
@@ -49,10 +49,10 @@ class ServiceClient:
         self._timeout = timeout
 
     def simple_call(self: "ServiceClient", method: str, params: Any) -> Any:
-        return self.make_kbase_jsonrpc_1_call(method, [params])[0]
+        return self.make_kbase_jsonrpc_1_call(f"{self._service}.{method}", [params])[0]
 
     def make_kbase_jsonrpc_1_call(
-        self: "ServiceClient", method: str, params: list[Any]
+        self: "ServiceClient", method: str, params: Any
     ) -> Any:
         """
         A very simple JSON-RPC 1 request maker for KBase services.
@@ -63,7 +63,7 @@ class ServiceClient:
         call_id = str(uuid.uuid4())
         json_rpc_package = {
             "params": params,
-            "method": f"{self._service}.{method}",
+            "method": method,
             "version": "1.1",
             "id": call_id,
         }

--- a/narrative_llm_agent/user_interface/components/narrative_data.py
+++ b/narrative_llm_agent/user_interface/components/narrative_data.py
@@ -1,0 +1,89 @@
+
+from typing import List
+from dash import dcc, Input, Output, State, callback, html
+import dash_bootstrap_components as dbc
+
+from narrative_llm_agent.kbase.clients.search import NarrativeDoc, Search
+from narrative_llm_agent.kbase.clients.workspace import Workspace
+from narrative_llm_agent.user_interface.constants import CREDENTIALS_STORE
+
+NARRATIVE_SEL = "narrative-select"
+OBJECT_SEL = "object-select"
+
+def narrative_data_dropdown():
+    return dbc.Row(
+        [
+            dbc.Col(
+                [
+                    html.H5("Narrative"),
+                    dcc.Dropdown(
+                        id=NARRATIVE_SEL,
+                    )
+                ]
+            ),
+            dbc.Col(
+                [
+                    html.H5("Object"),
+                    dcc.Dropdown(
+                        id=OBJECT_SEL
+                    )
+                ]
+            ),
+            html.Div(id="output-stuff")
+        ]
+    )
+
+@callback(
+    Output(NARRATIVE_SEL, "options"),
+    Input(CREDENTIALS_STORE, "modified_timestamp"),
+    State(CREDENTIALS_STORE, "data"),
+    prevent_initial_call=True
+)
+def init_narrative_dropdown(_, creds):
+    print("initing narratives")
+    if not creds.get("kb_user_id"):
+        return []
+    narratives = lookup_narratives(creds["kb_user_id"], creds["kb_auth_token"])
+    return [{"label": narr.narrative_title, "value": narr.access_group} for narr in narratives]
+
+
+@callback(
+    Output(OBJECT_SEL, "options"),
+    Input(NARRATIVE_SEL, "value"),
+    State(CREDENTIALS_STORE, "data"),
+    prevent_initial_call=True
+)
+def init_object_dropdown(narrative_id, creds):
+    print(f"initing objects - narrative_id {narrative_id}")
+    if not narrative_id:
+        return []
+    objs = sorted(lookup_objects(narrative_id, creds["kb_auth_token"]), key=lambda x: x["type"])
+    return [{
+        "label": f"{obj['name']} - {obj['type'].split('-')[0].split('.')[-1]}",
+        "value": obj["upa"]
+    } for obj in objs]
+
+@callback(
+    Output("output-stuff", "children"),
+    Input(NARRATIVE_SEL, "value"),
+    Input(OBJECT_SEL, "value"),
+    prevent_initial_call=True
+)
+def set_narr_and_upa(narrative_id, obj_upa):
+    if narrative_id is not None and obj_upa is not None:
+        return f"narrative - {narrative_id}, upa - {obj_upa}"
+    return "Nothing yet."
+
+def lookup_narratives(user_id: str, auth_token: str) -> List[NarrativeDoc]:
+    try:
+        search = Search(token=auth_token)
+        results = search.search_narratives(user_id)
+        return results.hits
+    except Exception as e:
+        raise e
+
+def lookup_objects(narrative_id: int, auth_token: str) -> List[dict[str, str]]:
+    ws = Workspace(token=auth_token)
+    objs = ws.list_workspace_objects(narrative_id, as_dict=True)
+    # filter out narratives and reports
+    return list(filter(lambda x: not x["type"].startswith("KBaseNarrative.Narrative"), objs))

--- a/narrative_llm_agent/user_interface/ui_dash_hitl.py
+++ b/narrative_llm_agent/user_interface/ui_dash_hitl.py
@@ -22,6 +22,7 @@ from narrative_llm_agent.user_interface.components.analysis_approval import (
 from narrative_llm_agent.user_interface.components.metadata_agent_format import (
     format_agent_response,
 )
+from narrative_llm_agent.user_interface.components.narrative_data import narrative_data_dropdown
 from narrative_llm_agent.user_interface.workflow_runners import generate_mra_draft, initialize_metadata_agent, run_analysis_planning
 from narrative_llm_agent.util.metadata_util import (
     check_metadata_completion,
@@ -247,6 +248,7 @@ def create_main_layout():
                     create_credentials_form(),
                     html.Br(),
                     # Metadata Collection Interface
+                    narrative_data_dropdown(),
                     create_metadata_collection_interface(),
                     html.Br(),
                     # Manual Input Form (backup/override)


### PR DESCRIPTION
This adds:
* a very basic search API client
* a couple of dropdowns (with some horrible styling) for selecting narratives and objects

The flow should be like this:
1. User logs in
2. That token shows up in the narrative dropdown callback, gets populated with most recent narratives
3. User selects a narrative (value is narrative_id)
4. This triggers populating the object dropdown
5. User selects an object (value is UPA)

Next step is to put that in a store (metadata store, maybe?) and have that update the metadata interaction section. Maybe give it a button to make it start? Something like that.

Anyway, I think that'll be more code changes, so while this is still incomplete, I'll stop it here.